### PR TITLE
content;build: fix local build imgs, add new page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,9 @@ jobs:
             ${{ runner.os }}-hugomod-
 
       - name: Build website
-        run: hugo --noChmod --minify
+        # See https://discourse.gohugo.io/t/solved-what-should-be-used-for-the-value-of-site-baseurl/5896
+        # for why we set baseURL here and not in hugo.toml.
+        run: hugo --noChmod --minify --baseURL="https://botlabs-gg.github.io/yagpdb-docs-v2"
 
       - name: Setup Pages
         id: pages

--- a/README.md
+++ b/README.md
@@ -12,15 +12,7 @@ As always clone the repository first and change into it.
 Install [Hugo](https://gohugo.io/getting-started/installing/), clone this repository and run `hugo server` to start a
 local server. The server will automatically rebuild the page when you make changes.
 
-Alternatively you can run `hugo` to build the page in release mode, which will output the static files to the `public`
-directory, which you can serve with any web server; a quick way is to use Python's `http.server` module:
-
-```shellsession
-$ hugo
-$ python3 -m http.server -d public/
-```
-
-By default, this will be accessible at `http://localhost:8000`.
+Due to the current configuration of `baseURL` in `hugo.toml`, the page is then available at `localhost:1313/yagpdb-docs-v2`.
 
 ### Editor Setup
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,5 @@
 +++
 title = 'Introduction'
-date = 2023-12-19T19:31:50+01:00
 +++
 
 > Documentation is for users. - Rob Pike
@@ -19,6 +18,9 @@ If you need help with YAGPDB, please join the [support server](https://discord.g
 channel. Any other online forum is not official and should be generally treated as inaccurate.
 
 Questions regarding the clarity of this documentation are also welcome, as they help us improve the documentation.
+
+Remember to first read `#information` and `#faq` before asking questions. Our support staff are volunteers, so please be
+patient when they don't respond in 10<sup>-3</sup> seconds, they are probably busy with something else.
 
 ### Learning Center
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,29 +1,41 @@
-baseURL = 'https://botlabs-gg.github.io/yagpdb-docs-v2'
+# To avoid weirdness with images and whatnot, this is empty and instead set at build time.
+# See also https://discourse.gohugo.io/t/solved-what-should-be-used-for-the-value-of-site-baseurl/5896
+baseURL = ''
 languageCode = 'en-us'
 title = 'YAGPDB Documentation v2'
 
+uglyURLs = true
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      # Enable HTML tags in Markdown
+      unsafe = true
+
 [module]
-[[module.imports]]
-path = 'github.com/McShelby/hugo-theme-relearn'
+  [[module.imports]]
+  path = 'github.com/McShelby/hugo-theme-relearn'
 
 [outputs]
-home = [ "HTML", "SEARCH" ]
+  home = [ "HTML", "SEARCH" ]
 
 [params]
-themeVariant = [
-    { identifier = "relearn-auto",  name = "Relearn Light/Dark", auto = [] },
-	{ identifier = "relearn-light"  },
-	{ identifier = "relearn-dark"   },
-	{ identifier = "relearn-bright" },
-	{ identifier = "zen-auto",      name = "Zen Light/Dark", auto = [ "zen-light", "zen-dark" ] },
-	{ identifier = "zen-light"      },
-	{ identifier = "zen-dark"       },
-	{ identifier = "neon"           },
-	{ identifier = "learn"          },
-	{ identifier = "blue"           },
-	{ identifier = "green"          },
-	{ identifier = "red"            }
-]
+  themeVariant = [
+  { identifier = "relearn-auto",  name = "Relearn Light/Dark", auto = [] },
+  { identifier = "relearn-light"  },
+  { identifier = "relearn-dark"   },
+  { identifier = "relearn-bright" },
+  { identifier = "zen-auto",      name = "Zen Light/Dark", auto = [ "zen-light", "zen-dark" ] },
+  { identifier = "zen-light"      },
+  { identifier = "zen-dark"       },
+  { identifier = "neon"           },
+  { identifier = "learn"          },
+  { identifier = "blue"           },
+  { identifier = "green"          },
+  { identifier = "red"            }
+  ]
 
-collapsibleMenu = true
-disableRootBreadcrumb = true
+  collapsibleMenu = true
+  disableRootBreadcrumb = true
+  disableInlineCopyToClipboard = true
+  editURL = 'https://github.com/botlabs-gg/yagpdb-docs-v2/edit/master/content/'

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,48 +1,48 @@
 <style>
+  a#R-logo {
+    color: #282828;
+    color: var(--MENU-SECTIONS-BG-color);
+    font-family: 'Work Sans', 'Helvetica', 'Tahoma', 'Geneva', 'Arial', sans-serif;
+    font-size: 1.875rem;
+    font-weight: 300;
+    margin-top: -.8125rem;
+    max-width: 60%;
+    text-transform: uppercase;
+    width: 14.125rem;
+    white-space: nowrap;
+  }
+
+  a#R-logo:hover {
+    color: #282828;
+    color: var(--MENU-SECTIONS-BG-color);
+  }
+
+  @media only all and (max-width: 59.999rem) {
     a#R-logo {
-        color: #282828;
-        color: var(--MENU-SECTIONS-BG-color);
-        font-family: 'Work Sans', 'Helvetica', 'Tahoma', 'Geneva', 'Arial', sans-serif;
-        font-size: 1.875rem;
-        font-weight: 300;
-        margin-top: -.8125rem;
-        max-width: 60%;
-        text-transform: uppercase;
-        width: 14.125rem;
-        white-space: nowrap;
+      font-size: 1.5625rem;
+      margin-top: -.1875rem;
+    }
+  }
+
+  @media all and (-ms-high-contrast:none) {
+      {
+        {
+        "/* IE11s understanding of positioning is weird at best */" | safeCSS
+      }
     }
 
-    a#R-logo:hover {
-        color: #282828;
-        color: var(--MENU-SECTIONS-BG-color);
+    a#R-logo {
+      margin-top: -3.625rem;
     }
+  }
 
-    @media only all and (max-width: 59.999rem) {
-        a#R-logo {
-            font-size: 1.5625rem;
-            margin-top: -.1875rem;
-        }
-    }
-
-    @media all and (-ms-high-contrast:none) {
-            {
-                {
-                "/* IE11s understanding of positioning is weird at best */" | safeCSS
-            }
-        }
-
-        a#R-logo {
-            margin-top: -3.625rem;
-        }
-    }
-
-    img {
-        margin-right: 0.5rem;
-        margin-top: -0.25rem;
-        vertical-align: middle;
-    }
+  img {
+    margin-right: 0.5rem;
+    margin-top: -0.25rem;
+    vertical-align: middle;
+  }
 </style>
 
-<a id="R-logo" href="/">
-    <img src="images/logo.png" width=30px height=30px>YAGPDB
+<a id="R-logo" href="{{ relURL "" }}">
+  <img src="/images/logo.png" width=30px height=30px>YAGPDB
 </a>


### PR DESCRIPTION
Parts of the build (mainly images) were broken when testing on localhost.
This is because of baseURL weirdness; see the added comments in hugo.toml and deploy.yml.

Add a new page `getting-started.md`; it is not yet finished.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
