### PR TITLE
ci: fix cache, improve feedback and build times

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,7 @@ name: Deploy Hugo site to GH Pages
 on:
   # Only deploy when it is accepted for production
   push:
-    branches:
-      - master
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -16,6 +15,9 @@ permissions:
 concurrency:
   group: "pages"
   cancel-in-progress: false
+
+env:
+  HUGO_CACHEDIR: /tmp/hugo_cache/
 
 jobs:
   build:
@@ -35,7 +37,7 @@ jobs:
       - name: Cache Hugo modules
         uses: actions/cache@v3
         with:
-          path: /home/runner/.cache/hugo_cache
+          path: ${{ env.HUGO_CACHEDIR }}
           key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-hugomod-
@@ -46,15 +48,19 @@ jobs:
         run: hugo --noChmod --minify --baseURL="https://botlabs-gg.github.io/yagpdb-docs-v2"
 
       - name: Setup Pages
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         id: pages
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: actions/upload-pages-artifact@v2
         with:
           path: ./public
 
   deploy:
+    # Only deploy if it's actually on main branch
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     needs: build
     environment:
       name: github-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,19 +48,19 @@ jobs:
         run: hugo --noChmod --minify --baseURL="https://botlabs-gg.github.io/yagpdb-docs-v2"
 
       - name: Setup Pages
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         id: pages
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: actions/upload-pages-artifact@v2
         with:
           path: ./public
 
   deploy:
-    # Only deploy if it's actually on main branch
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    # Only deploy if it's actually on production branch
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     needs: build
     environment:
       name: github-pages


### PR DESCRIPTION
Fix hugo_cache not being where we expect it to be by setting the
HUGO_CACHEDIR env variable to something predetermined.

Improve the feedback on PRs by now also running on pull requests, but
then only build the website to catch some errors; do not set up GH Pages
nor upload any pages artifact.
Future work may entail adding some linters and grammar checkers.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
