### PR TITLE
hugo: vendor modules before building page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ concurrency:
 
 env:
   HUGO_CACHEDIR: /tmp/hugo_cache/
+  HUGO_BASE_URL: "https://botlabs.gg.github.io/yagpdb-docs-v2"
 
 jobs:
   build:
@@ -45,7 +46,7 @@ jobs:
       - name: Build website
         # See https://discourse.gohugo.io/t/solved-what-should-be-used-for-the-value-of-site-baseurl/5896
         # for why we set baseURL here and not in hugo.toml.
-        run: hugo --noChmod --minify --baseURL="https://botlabs-gg.github.io/yagpdb-docs-v2"
+        run: hugo mod vendor && hugo --minify --baseURL=${{ env.HUGO_BASE_URL }}
 
       - name: Setup Pages
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ As always clone the repository first and change into it.
 Install [Hugo](https://gohugo.io/getting-started/installing/), clone this repository and run `hugo server` to start a
 local server. The server will automatically rebuild the page when you make changes.
 
+To build the page in release mode:
+
+1. `hugo mod vendor`
+2. `hugo`
+
+Then serve the generated `public/` directory with the webserver of your choice. Adjust the `--baseURL` argument to
+`hugo` as required.
+
 ### Editor Setup
 
 As this project used the [EditorConfig](https://editorconfig.org/) standard, you will have to make sure that your


### PR DESCRIPTION
Vendor hugo modules into `_vendor/` before building the page in release
mode (i.e. with `hugo`).

Reportedly, hugo tends to fail with odd errors along the lines of
"Permission denied" when trying to build the site, due to some weird
file permissions on the (elsewhere) vendored module files.

Testing has concluded that running `hugo mod vendor` before building the
page fixes this issue as far as I can tell. Adjust the build
instructions in the README.md file to reflect this oddity.

Closes botlabs-gg/yagpdb-docs-v2#6 ("Fix Hugo Builds For Good").

Signed-off-by: Luca Zeuch <l-zeuch@email.de>