### PR TITLE
partials: fix weird underline in menu sidebar

### DIFF
--- a/layouts/partials/menu-footer.html
+++ b/layouts/partials/menu-footer.html
@@ -1,21 +1,21 @@
 <!-- make sure links are visible as such -->
 <style>
-  a {
+  p.menu-footer > a {
     text-decoration: underline !important;
   }
 </style>
 
-<p>
+<p class="menu-footer">
   Text available under <a href="https://creativecommons.org/licenses/by-sa/4.0/"
     title="CC-BY-SA license">CC-BY-SA</a>; additional terms may apply.
 </p>
-<p>
+<p class="menu-footer">
   By using this site, you agree to our <a href="https://yagpdb.xyz/terms-of-use" title="Terms of Use">Terms of Use</a>
   and <a href="https://botlabs.gg/privacy-policy" title="Privacy Policy">Privacy Policy</a>.
 </p>
 
 <!-- required to adhere to MIT license terms -->
-<p>
+<p class="menu-footer">
   Built with <a href="https://github.com/McShelby/hugo-theme-relearn" title="love"><i class="fas fa-heart"></i></a>
   by <a href="https://gohugo.io/">Hugo</a>
 </p>


### PR DESCRIPTION
Fix the unintentional underlining of other links in the menu sidebar by
assigning the `p` elements in the menu-footer partial a special class,
which we then specifically select for.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>
