### PR TITLE
workflows: rename deploy.yml to hugo.yml

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,5 +1,5 @@
 ---
-name: Deploy Hugo site to GH Pages
+name: Hugo (CD)
 
 on:
   # Only deploy when it is accepted for production
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   HUGO_CACHEDIR: /tmp/hugo_cache/
-  HUGO_BASE_URL: "https://botlabs.gg.github.io/yagpdb-docs-v2"
+  HUGO_BASE_URL: "https://botlabs-gg.github.io/yagpdb-docs-v2"
 
 jobs:
   build:


### PR DESCRIPTION
Rename the workflow from deploy.yml to hugo.yml to be more descriptive
of what it is actually doing, given that it only really deploys when a
commit is pushed to the master (i.e. production) branch.

While we're at it, also fix a small typo messing up the HUGO_BASE_URL,
it should be botlabs-gg, not botlabs.gg.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>