### PR TITLE
docs/main: refine first two pages

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -46,6 +46,8 @@ can help them. This is a great way to give back to the community and help the pr
 
 <!-- TODO: maybe add a guide for selfhosting? -->
 
+#### Improving the Bot
+
 Additionally, you can contribute to YAGPDB itself by submitting pull requests to the [GitHub repository](https://botlabs-gg/yagpdb)
 if you are feeling comfortable with [Go](https://golang.org/).
 
@@ -53,3 +55,8 @@ Please take a closer look at the [contributing guidelines](https://github.com/bo
 to increase the chances of your pull request being accepted; a good starting point is also to implement highly-upvoted
 suggestions in the `#suggestions` channel on the support server.
 
+#### Writing Documentation
+
+If you feel that contributing to the bot itself is a bit too daunting, you are just as welcome to write and improve this
+documentation. All you really need is a decent (text) editor of your choice and a good look at our [docs contributing
+guidelines](https://github.com/botlabs-gg/yagpdb-docs-v2/blob/master/.github/CONTRIBUTING.md).

--- a/content/getting-started.md
+++ b/content/getting-started.md
@@ -18,7 +18,7 @@ You need to have the **Manage Server** permission to add the bot to your server.
 3. Authorize the application to know what servers you are in
 4. Select the server you want to add the bot to in the dropdown menu
 
-## First Steps
+### First Steps
 
 Before doing anything, you should first take a closer look at the Control Panel you just opened. It is the main
 interface for configuring the bot, and is where you will spend most of your time. Visit a few subpages to get a feel for
@@ -36,3 +36,8 @@ conflict with other bots you may have. Also make sure to enable all commands, su
 
 Try some commands! Something like `catfact` or `dadjoke`, to get the party going.
 If those did not work, please read the FAQ on the support server.
+
+## About this Documentation
+
+This documentation aims to go through all of YAGPDB's features as they appear in the order on the control panel.
+Reference material, or miscellaneous topics are in their own category as to not bloat things up with unnecessary detail.


### PR DESCRIPTION

<!-- Please describe the changes this pull request does and why it should be merged -->
Refine the first two pages, mentioning the option to also contribute to
the documentation, and how the docs are intended to be structured.

Given how the docs repo is fairly hidden from public view (at least on
the support server), it is certainly worth mentioning *where* it is to
increase the chances of outside contributors seeing it.

The small note how we intend to structure the documentation serves the
simple and benign purpose of improving the reader's flow, even though
the menu sidebar should already do most of that.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
