### PR TITLE
hugo: generate dedicated search-page

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -17,7 +17,7 @@ uglyURLs = true
   path = 'github.com/McShelby/hugo-theme-relearn'
 
 [outputs]
-  home = [ "HTML", "SEARCH" ]
+  home = [ "html", "search", "searchpage" ]
 
 [params]
   themeVariant = [


### PR DESCRIPTION
Tell Hugo to generate a dedicated search-page, improving UX when using
the included search-bar.

Currently, it just does nothing; that way, users will be redirected to
said dedicated page, listing all more or less matching results.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
