### PR TITLE
General Housekeeping / Formatting Tasks

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -25,18 +25,9 @@ uglyURLs = true
 
 [params]
   themeVariant = [
-  { identifier = "relearn-auto",  name = "Relearn Light/Dark", auto = [] },
-  { identifier = "relearn-light"  },
-  { identifier = "relearn-dark"   },
-  { identifier = "relearn-bright" },
-  { identifier = "zen-auto",      name = "Zen Light/Dark", auto = [ "zen-light", "zen-dark" ] },
-  { identifier = "zen-light"      },
-  { identifier = "zen-dark"       },
-  { identifier = "neon"           },
-  { identifier = "learn"          },
-  { identifier = "blue"           },
-  { identifier = "green"          },
-  { identifier = "red"            }
+    { identifier = "zen-auto", name = "Zen Light/Dark", auto = [ "zen-light", "zen-dark" ] },
+    { identifier = "zen-light" },
+    { identifier = "zen-dark"  },
   ]
 
   collapsibleMenu = true

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,6 +7,10 @@ title = 'YAGPDB Documentation v2'
 uglyURLs = true
 
 [markup]
+  [markup.tableOfContents]
+    # Some relatively important headers, like cc triggers, are on level 4;
+    # we want to have those in our table of contents, so we need to set this to 4.
+    endLevel = 4
   [markup.goldmark]
     [markup.goldmark.renderer]
       # Enable HTML tags in Markdown

--- a/layouts/partials/custom-header.html
+++ b/layouts/partials/custom-header.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="{{ relURL "css/menu.css" }}">

--- a/static/css/menu.css
+++ b/static/css/menu.css
@@ -1,0 +1,6 @@
+/* Increase the margin a little bit such that it doesn't look too crowded
+ * on the menu side bar.
+ */
+#R-topics {
+  margin-left: 0.5em;
+}


### PR DESCRIPTION
This CL is a combination of three commits. Due to the nature of this
branch ("general housekeeping"), I'll be merging this via a merge commit
rather than our usual squash-merge strategy, as the commits are
logically disjoint and don't really make sense to be squashed together.

* hugo: increase ToC endLevel to 4

    Increase the markup.tableOfContents endLevel config to 4, so that some
    relatively deeply nested headers still show up in the individual page's
    ToC.

    This may be especially important for future pages such as template
    references, where we'll be using those higher-level headers fairly
    extensively.

    Signed-off-by: Luca Zeuch <l-zeuch@email.de>

* hugo: remove some useless/ugly themes

    Remove most of the themes that have no use beyond changing a single
    colour around, or are just not very nice to look at / redundant compared
    to other themes.

    Internal voting has concluded that we want to keep the Zen theme. A
    custom theme based on YAGPDB's colours is also being considered and
    should hopefully be the default in the future.

    Signed-off-by: Luca Zeuch <l-zeuch@email.de>

* layout: increase margin on menu sidebar items

    Increase the margin on menu sidebar items (`#R-Topics`).

    Prior to this change, the arrows of said items were quite close to the
    edge of the viewport / screen, which makes for an... interesting
    experience to look at.

    Personal testing and consulting with one other person has concluded that
    0.5em is good enough(tm).

    Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
