### PR TITLE
workflows: update workflow actions

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: latest
           # We use the extended version just to be on the safe side.
@@ -36,7 +36,7 @@ jobs:
           extended: true
 
       - name: Cache Hugo modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.HUGO_CACHEDIR }}
           key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.sum') }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload artifact
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 


### PR DESCRIPTION
Update the workflow actions used in hugo.yml.

GitHub Actions emits some warnings regarding Node 16 deprecation and
recommends updating the workflows to the latest version running on Node
20.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
