### PR TITLE
general: add menu icons for pages

### DIFF
--- a/content/core/_index.md
+++ b/content/core/_index.md
@@ -2,6 +2,7 @@
 archetype = "chapter"
 title = "Core"
 weight = 3
+menuPre = "<i class= 'fas fa-cogs'></i> "
 +++
 
 Under the **Core** category of the control panel, you can configure access to

--- a/content/core/all-commands.md
+++ b/content/core/all-commands.md
@@ -1,6 +1,7 @@
 +++
 title = 'All Commands'
 weight = 4
+menuPre = "<i class= 'fas fa-list'></i> "
 +++
 
 List of all available commands offered by YAGPDB and their syntax.

--- a/content/core/command-settings.md
+++ b/content/core/command-settings.md
@@ -1,6 +1,7 @@
 +++
 title = 'Command Settings'
 weight = 3
+menuPre = "<i class= 'fas fa-terminal'></i> "
 +++
 
 Fine-grained control over all of YAGPDB's inbuilt commands.

--- a/content/core/control-panel-access.md
+++ b/content/core/control-panel-access.md
@@ -1,6 +1,7 @@
 +++
 title = 'Control Panel Access'
 weight = 1
+menuPre = "<i class= 'fas fa-cog'></i> "
 +++
 
 Select who can view or edit your control panel.

--- a/content/core/control-panel-logs.md
+++ b/content/core/control-panel-logs.md
@@ -1,6 +1,7 @@
 +++
 title = 'Control Panel Logs'
 weight = 2
+menuPre = "<i class= 'fas fa-database'></i> "
 +++
 
 View a list of recent changes to your YAGPDB configuration.

--- a/content/custom-commands/_index.md
+++ b/content/custom-commands/_index.md
@@ -2,6 +2,7 @@
 archetype = "chapter"
 title = "Custom Commands"
 weight = 4
+menuPre = "<i class= 'fas fa-closed-captioning'></i> "
 +++
 
 Custom commands (abbreviated **CCs**) allow you to develop your own commands and behaviors for your server. A command

--- a/content/custom-commands/commands.md
+++ b/content/custom-commands/commands.md
@@ -1,6 +1,7 @@
 +++
 title = 'Commands'
 weight = 1
+menuPre = "<i class= 'fas fa-code'></i> "
 +++
 
 The commands page displays all custom commands and allows you to add, delete, or edit custom commands and custom command

--- a/content/custom-commands/database.md
+++ b/content/custom-commands/database.md
@@ -1,6 +1,7 @@
 +++
 title = 'Database'
 weight = 2
+menuPre = "<i class= 'fas fa-database'></i> "
 +++
 
 The Custom Command Database is used for persistent storage between custom command executions. The database page displays

--- a/content/fun/_index.md
+++ b/content/fun/_index.md
@@ -2,6 +2,7 @@
 archetype = "chapter"
 title = "Fun"
 weight = 7
+menuPre = "<i class= 'fas fa-trophy'></i> "
 +++
 
 Fun commands and systems provide engaging ways to enrich your server environment.

--- a/content/fun/reputation.md
+++ b/content/fun/reputation.md
@@ -1,6 +1,7 @@
 +++
 title = 'Reputation'
 weight = 1
+menuPre = "<i class= 'fas fa-angry'></i> "
 +++
 
 The reputation system tracks each user's reputation score, and allows users to add or remove reputation points from

--- a/content/fun/soundboard.md
+++ b/content/fun/soundboard.md
@@ -1,6 +1,7 @@
 +++
 title = 'Soundboard'
 weight = 2
+menuPre = "<i class= 'fas fa-border-all'></i> "
 +++
 
 The soundboard system allows the bot to join a voice channel, and play sounds triggered by soundboard commands.

--- a/content/getting-started.md
+++ b/content/getting-started.md
@@ -1,6 +1,7 @@
 +++
 title = 'Getting Started'
 weight = 1
+menuPre = "<i class= 'fas fa-rocket'></i> "
 +++
 
 > The hardest thing about getting started, is getting started. - Guy Kawasaki

--- a/content/moderation/_index.md
+++ b/content/moderation/_index.md
@@ -2,6 +2,7 @@
 archetype = "chapter"
 title = "Moderation"
 weight = 5
+menuPre = "<i class= 'fas fa-user-shield'></i> "
 +++
 
 {{%children containerstyle="div" style="h2" description="true" %}}

--- a/content/moderation/advanced-automoderator/_index.md
+++ b/content/moderation/advanced-automoderator/_index.md
@@ -1,6 +1,7 @@
 +++
 title = 'Advanced Automoderator'
 weight = 3
+menuPre = "<i class= 'fas fa-robot'></i> "
 +++
 
 A sophisticated automoderator system, allowing for more complex configurations than basic automoderator.

--- a/content/moderation/advanced-automoderator/conditions.md
+++ b/content/moderation/advanced-automoderator/conditions.md
@@ -1,6 +1,7 @@
 +++
 title = 'Conditions'
 weight = 2
+menuPre = "<i class= 'fas fa-filter'></i> "
 +++
 
 Conditions impose more fine-grained control on Advanced Automoderator rules. This page will cover the different types

--- a/content/moderation/advanced-automoderator/effects.md
+++ b/content/moderation/advanced-automoderator/effects.md
@@ -1,6 +1,7 @@
 +++
 title = 'Effects'
 weight = 3
+menuPre = "<i class= 'fas fa-forward'></i> "
 +++
 
 Effects define what happens when a rule is triggered and all conditions are met. This page will cover the different

--- a/content/moderation/advanced-automoderator/triggers.md
+++ b/content/moderation/advanced-automoderator/triggers.md
@@ -1,6 +1,7 @@
 +++
 title = 'Triggers'
 weight = 1
+menuPre = "<i class= 'fas fa-play'></i> "
 +++
 
 Triggers define when a rule should be checked. This page will explain the available triggers and their configuration

--- a/content/moderation/basic-automoderator.md
+++ b/content/moderation/basic-automoderator.md
@@ -1,6 +1,7 @@
 +++
 title = 'Basic Automoderator'
 weight = 2
+menuPre = "<i class= 'fas fa-robot'></i> "
 +++
 
 A very basic automoderator to get things done quickly.

--- a/content/moderation/logging.md
+++ b/content/moderation/logging.md
@@ -1,6 +1,7 @@
 +++
 title = 'Logging'
 weight = 4
+menuPre = "<i class= 'fas fa-database'></i> "
 +++
 
 Capture a moment in time with message logging of the last messages in a channel when the log is created, including a

--- a/content/moderation/moderation-overview.md
+++ b/content/moderation/moderation-overview.md
@@ -2,6 +2,7 @@
 archetype = "default"
 title = "Moderation"
 weight = 1
+menuPre = "<i class= 'fas fa-gavel'></i> "
 +++
 
 Everything in moderation, including moderation.

--- a/content/moderation/verification.md
+++ b/content/moderation/verification.md
@@ -1,6 +1,7 @@
 +++
 title = 'Verification'
 weight = 5
+menuPre = "<i class= 'fas fa-address-card'></i> "
 +++
 
 Use Google reCAPTCHA v2 to verify your members before permitting them access to your server.

--- a/content/notifications/_index.md
+++ b/content/notifications/_index.md
@@ -2,6 +2,7 @@
 archetype = "chapter"
 title = 'Notifications and Feeds'
 weight = 6
+menuPre = "<i class= 'fas fa-rss'></i> "
 +++
 
 YAGPDB offers you a variety of ways to keep up with what's happening, such as users joining, leaving, new Reddit posts,

--- a/content/notifications/general.md
+++ b/content/notifications/general.md
@@ -1,6 +1,7 @@
 +++
 title = 'General'
 weight = 1
+menuPre = "<i class= 'fas fa-bell'></i> "
 +++
 
 General notifications such as a welcoming direct message, a message in the server when users join or leave, as well as a

--- a/content/notifications/reddit.md
+++ b/content/notifications/reddit.md
@@ -1,6 +1,7 @@
 +++
 title = 'Reddit'
 weight = 2
+menuPre = "<i class= 'fab fa-reddit'></i> "
 +++
 
 Get notifications from your favorite subreddits directly in your Discord server.

--- a/content/notifications/streaming.md
+++ b/content/notifications/streaming.md
@@ -1,6 +1,7 @@
 +++
 title = 'Streaming'
 weight = 4
+menuPre = "<i class= 'fas fa-video'></i> "
 +++
 
 Let everyone know that someone is currently streaming.

--- a/content/notifications/youtube.md
+++ b/content/notifications/youtube.md
@@ -1,6 +1,7 @@
 +++
 title = 'YouTube'
 weight = 3
+menuPre = "<i class= 'fab fa-youtube'></i> "
 +++
 
 Get notifications from your favorite YouTubers directly in your Discord server.

--- a/content/premium.md
+++ b/content/premium.md
@@ -1,6 +1,7 @@
 +++
 title = 'Premium'
 weight = 2
+menuPre = "<i class= 'fas fa-star'></i> "
 +++
 
 YAGPDB provides added functionality to servers which are assigned a premium slot by a user. On the official instance of

--- a/content/reference/_index.md
+++ b/content/reference/_index.md
@@ -2,6 +2,7 @@
 archetype = "chapter"
 title = "Reference"
 weight = 8
+menuPre = "<i class= 'fas fa-question'></i> "
 +++
 
 Reference documentation provides further information about advanced customization with YAGPDB, particularly focused


### PR DESCRIPTION
For your consideration: Icons in menu options.

### Pros
1. Break up the text wall
2. Familiarity
3. Easy navigation to the section you're looking for when coming from the control panel

### Cons
1. More visually busy
2. There are more docs pages than there are pages on YAG, users may be confused why there's a page with an icon in
docs' menu bar but not able to find the page on control panel
3. Easier for new users to mistake docs for control panel

Please take a look and share thoughts (or deny instantly, whichever works :)) https://yagdocsv2.vedamaharaj.ca/yagpdb-docs-v2/

**Terms**
- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
