### PR TITLE
callouts: standardize callouts

### DIFF
--- a/.vscode/markdown.code-snippets
+++ b/.vscode/markdown.code-snippets
@@ -2,7 +2,7 @@
 	"Info callout": {
 		"prefix": "note",
 		"body": [
-			"{{< callout context=\"info\" title=\"${1:Note}\" icon=\"outline/info-circle\" >}}",
+			"{{< callout context=\"note\" title=\"${1:Note}\" icon=\"outline/info-circle\" >}}",
 			"",
 			"$0",
 			"",

--- a/content/docs/core/command-settings.md
+++ b/content/docs/core/command-settings.md
@@ -81,7 +81,7 @@ Clicking on either of these options (**3**,**4**) opens a drop-down menu with al
 Select as many as you wish. YAGPDB will then either require all members to have any of these roles in order to run
 commands, or completely ignore members with any of the ignored roles, server admins and owners included.
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 YAGPDB was raised well and honors a "no" when told "no". In other words, ignored roles take precedence over required
 roles.

--- a/content/docs/core/command-settings.md
+++ b/content/docs/core/command-settings.md
@@ -27,14 +27,14 @@ prefix was instead `?`, one would use `?remindme ...`, and so on.
 
 Slash commands are always triggered using the `/` character and hence do not depend on the prefix configured here.
 
-{{< callout context="tip" icon="outline/rocket" >}}
+{{< callout context="tip" title="Tip" icon="outline/rocket" >}}
 
 In addition to the command prefix, you can trigger YAGPDB commands by pinging the bot at the start of your message. This
 is helpful if you forget your prefix, as sending `@YAGPDB.xyz prefix` will recall it.
 
 {{< /callout >}}
 
-{{< callout context="caution" title="Flags and Switches" >}}
+{{< callout context="caution" title="Flags and Switches" icon="outline/alert-triangle" >}}
 
 Flags and switches are **_not_** affected by your prefix setting.
 
@@ -59,7 +59,7 @@ Command overrides are considered in the following order, with settings applied a
 The order above trickles down from least specific to most specific, prioritizing the most specific setting -- an analogy
 for developers would be CSS's cascading rules.
 
-{{< callout context="note" title="Example" >}}
+{{< callout context="note" title="Example" icon="outline/info-circle" >}}
 
 Though perhaps confusing at first, the priority order above is designed to make common configurations trivial. For
 instance, to disable all but a specific command -- say the `remindme` command -- one can simply disable the _All
@@ -81,7 +81,7 @@ Clicking on either of these options (**3**,**4**) opens a drop-down menu with al
 Select as many as you wish. YAGPDB will then either require all members to have any of these roles in order to run
 commands, or completely ignore members with any of the ignored roles, server admins and owners included.
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 YAGPDB was raised well and honors a "no" when told "no". In other words, ignored roles take precedence over required
 roles.
@@ -102,7 +102,7 @@ If 10 seconds are not enough, or too long, feel free to adjust as you see fit; t
 These options are only available for channel overrides (**8**). To add a new one, head to the _New channel override_
 tab on the command settings page.
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 You must select at least one channel or category; otherwise, the settings of the override will not be applied.
 

--- a/content/docs/custom-commands/commands.md
+++ b/content/docs/custom-commands/commands.md
@@ -82,7 +82,7 @@ Using role/channel restrictions, it is possible to set conditions on which users
 Specifically, whitelisted roles or channels are required to run the command, whereas blacklisted roles or channels
 cannot use the command at all.
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 YAGPDB was raised well and honors a "no" when told "no". In other words, blacklists take precedence over whitelists.
 
@@ -90,7 +90,7 @@ This is a relatively common trip-hazard, so take great care when you set up both
 
 {{< /callout >}}
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Role restrictions are unrelated to member permissions. Having `Administrator` permissions will not override these
 restrictions.
@@ -126,7 +126,7 @@ commands like `customcommands` accept a CC ID as an argument.
 
 Within a command response, the ID may be retrieved using the `{{ .CCID }}` template.
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 Deleting a custom command does not allow its ID to be reassigned. If you delete a CC, its ID is lost forever.
 
@@ -233,7 +233,7 @@ When editing an interval command, a **Run Now** button appears at the bottom of 
 long as the command is not disabled and a channel is selected. Running an interval command using this button reschedules
 all subsequent runs based off the current time.
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 You must specify a channel to run interval commands in even if the command doesn't output a message.
 
@@ -368,7 +368,7 @@ for the best coding experience.
 
 {{< /callout >}}
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 Custom commands do not autosave.
 

--- a/content/docs/custom-commands/commands.md
+++ b/content/docs/custom-commands/commands.md
@@ -82,7 +82,7 @@ Using role/channel restrictions, it is possible to set conditions on which users
 Specifically, whitelisted roles or channels are required to run the command, whereas blacklisted roles or channels
 cannot use the command at all.
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 YAGPDB was raised well and honors a "no" when told "no". In other words, blacklists take precedence over whitelists.
 
@@ -90,7 +90,7 @@ This is a relatively common trip-hazard, so take great care when you set up both
 
 {{< /callout >}}
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Role restrictions are unrelated to member permissions. Having `Administrator` permissions will not override these
 restrictions.
@@ -233,7 +233,7 @@ When editing an interval command, a **Run Now** button appears at the bottom of 
 long as the command is not disabled and a channel is selected. Running an interval command using this button reschedules
 all subsequent runs based off the current time.
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 You must specify a channel to run interval commands in even if the command doesn't output a message.
 

--- a/content/docs/fun/soundboard.md
+++ b/content/docs/fun/soundboard.md
@@ -20,7 +20,7 @@ Choose to require users to have a role in order to play this sound.
 
 ### Upload file
 
-{{< callout context="tip" icon="outline/rocket" >}}
+{{< callout context="tip" title="Tip" icon="outline/rocket" >}}
 
 Do **not** fill in the URL if you are going uploaded from local files, and vice versa.
 
@@ -40,7 +40,7 @@ tracks, are supported.
 
 You can also specify a sound URL instead of uploading one.&#x20;
 
-{{< callout context="tip" icon="outline/rocket" >}}
+{{< callout context="tip" title="Tip" icon="outline/rocket" >}}
 
 This has to be the direct link to the media file, and not a YouTube link. A direct link should end with`.mp3`(or other
 relevant audio/video type), such as

--- a/content/docs/moderation/advanced-automoderator/conditions.md
+++ b/content/docs/moderation/advanced-automoderator/conditions.md
@@ -21,7 +21,7 @@ By extension, these conditions are also available as ruleset scoped conditions.
 All conditions have to be met in order for a rule to execute — that is, the conditions are combined according to the
 logical AND operator.
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 Ensure that the conditions you set are not in conflict or mutually exclusive, as this will cause your rule to never
 trigger.

--- a/content/docs/moderation/logging.md
+++ b/content/docs/moderation/logging.md
@@ -8,7 +8,7 @@ limited number of deleted messages.
 
 <!--more-->
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 YAGPDB IS NOT A LOGGING BOT.
 
@@ -23,7 +23,7 @@ The log is accessible on YAGPDB's website for later viewing. It saves message ti
 User ID, and the message itself. If a message contains an attachment, the attachment URL is logged. If a message
 contains an embed, it is serialized and saved in JSON format.
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 Message logs on the official YAGPDB instance will be automatically deleted after 30 days of their creation.
 

--- a/content/docs/moderation/logging.md
+++ b/content/docs/moderation/logging.md
@@ -8,7 +8,7 @@ limited number of deleted messages.
 
 <!--more-->
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 YAGPDB IS NOT A LOGGING BOT.
 

--- a/content/docs/moderation/moderation-overview.md
+++ b/content/docs/moderation/moderation-overview.md
@@ -186,7 +186,7 @@ mute tab on the control panel.
 
 [Unmute Command Syntax](/docs/core/all-commands#unmute)
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 Within a server channel's permission overrides, allowing a permission to a specific role or user supersedes disallowing
 a permission to a specific role. This means if you grant Role X the permission to send messages in a channel and
@@ -200,7 +200,7 @@ when configuring other roles' permission overrides.
 
 {{< /callout >}}
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 If you set a duration for the mute, the bot will unmute the user after the specified duration. When this occurs, it
 appears as an unmute action taken by YAGPDB in your mod log, regardless of which moderator initially muted the user.
@@ -238,7 +238,7 @@ field in the ban tab on the control panel which enables automatic deletion when 
 
 [Unban Command Syntax](/docs/core/all-commands#unban)
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 If you set a duration for the ban, the bot will unban the user after the specified duration. When this occurs, it
 appears as an unban action taken by YAGPDB in your mod log, regardless of which moderator initially banned the user.

--- a/content/docs/moderation/moderation-overview.md
+++ b/content/docs/moderation/moderation-overview.md
@@ -200,7 +200,7 @@ when configuring other roles' permission overrides.
 
 {{< /callout >}}
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 If you set a duration for the mute, the bot will unmute the user after the specified duration. When this occurs, it
 appears as an unmute action taken by YAGPDB in your mod log, regardless of which moderator initially muted the user.
@@ -238,7 +238,7 @@ field in the ban tab on the control panel which enables automatic deletion when 
 
 [Unban Command Syntax](/docs/core/all-commands#unban)
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 If you set a duration for the ban, the bot will unban the user after the specified duration. When this occurs, it
 appears as an unban action taken by YAGPDB in your mod log, regardless of which moderator initially banned the user.

--- a/content/docs/moderation/verification.md
+++ b/content/docs/moderation/verification.md
@@ -17,7 +17,7 @@ This is accomplished by sending new members a customizable DM (which employs [te
 containing a unique link to verify, tied to their User ID. This link takes them to a customizable verification page with
 a CAPTCHA challenge. Once completed, the User ID is assigned the verified role.
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 You must assign a "Verified Role" on the Verification page in the control panel. The plugin will not function if no role
 is selected.
@@ -75,7 +75,7 @@ Logged events are:
 
 ## Alt Detection
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Alt Detection is currently disabled on the official instance of YAGPDB hosted by Botlabs. These features will not
 function on the official bot.

--- a/content/docs/moderation/verification.md
+++ b/content/docs/moderation/verification.md
@@ -17,7 +17,7 @@ This is accomplished by sending new members a customizable DM (which employs [te
 containing a unique link to verify, tied to their User ID. This link takes them to a customizable verification page with
 a CAPTCHA challenge. Once completed, the User ID is assigned the verified role.
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 You must assign a "Verified Role" on the Verification page in the control panel. The plugin will not function if no role
 is selected.
@@ -47,7 +47,7 @@ You can customize both messages in the Verification page on the control panel.
 Verification scripts provide `.Link` as additional dot context data. This is the unique verification link the user must
 visit to verify.
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 If a user has disabled DMs from server members by default, upon joining your server YAGPDB will fail to send a
 verification DM to the user. It is recommended that you inform your new members about this possibility and how to fix it
@@ -75,7 +75,7 @@ Logged events are:
 
 ## Alt Detection
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Alt Detection is currently disabled on the official instance of YAGPDB hosted by Botlabs. These features will not
 function on the official bot.

--- a/content/docs/notifications/general.md
+++ b/content/docs/notifications/general.md
@@ -31,7 +31,7 @@ Write a message that you want the bot to send to the user via DM whenever someon
 Choose what channel you want the bot to announce the topic change from a specific channel or the channel that the topic
 was changed in.
 
-{{< callout context="tip" icon="outline/rocket" >}}
+{{< callout context="tip" title="Tip" icon="outline/rocket" >}}
 
 Custom command templates are supported for usage in all the notification feeds provided.
 

--- a/content/docs/notifications/reddit.md
+++ b/content/docs/notifications/reddit.md
@@ -7,8 +7,10 @@ Get notifications from your favorite subreddits directly in your Discord server.
 
 <!--more-->
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
+
 Fast Reddit feeds to the **top 10 subreddits** are disabled, due to being too spammy for YAGPDB's current system.
+
 {{< /callout >}}
 
 ## Reddit Feed

--- a/content/docs/notifications/streaming.md
+++ b/content/docs/notifications/streaming.md
@@ -9,7 +9,7 @@ Let everyone know that someone is currently streaming.
 
 ### Streaming Feed
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 There are currently some issues with the streaming announcement, and it may not always give the announcement. It will
 however, always assign the streamer role.

--- a/content/docs/notifications/streaming.md
+++ b/content/docs/notifications/streaming.md
@@ -9,14 +9,18 @@ Let everyone know that someone is currently streaming.
 
 ### Streaming Feed
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+
 There are currently some issues with the streaming announcement, and it may not always give the announcement. It will
 however, always assign the streamer role.
+
 {{< /callout >}}
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
+
 The streaming role will be **automatically removed** from a member that is not streaming if it is given manually, so be
 careful! If YAGPDB is removing member's roles without apparent reason, this may well be the cause.
+
 {{< /callout >}}
 
 ![Showcase of the streaming feed interface.](./streaming.png)

--- a/content/docs/notifications/youtube.md
+++ b/content/docs/notifications/youtube.md
@@ -9,7 +9,7 @@ Get notifications from your favorite YouTubers directly in your Discord server.
 
 ## YouTube Feed
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 Do **NOT** fill in both the Channel ID and the Channel URL.
 

--- a/content/docs/reference/custom-command-examples.md
+++ b/content/docs/reference/custom-command-examples.md
@@ -7,7 +7,7 @@ Prebuilt custom commands for use as a learning reference.
 
 <!--more-->
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 Note: This page is no longer updated with the latest versions of codes/commands. If you plan to copy paste codes for
 your server, see [this website](https://yagpdb-cc.github.io) which is frequently updated with new community-contributed
@@ -15,7 +15,7 @@ commands.
 
 {{< /callout >}}
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 This isn't the actual page about custom commands. A brief overview about custom commands can be found in the
 [Custom Commands documentation](/docs/custom-commands/commands). Please take notice, some of examples presented here are not up to

--- a/content/docs/reference/custom-command-examples.md
+++ b/content/docs/reference/custom-command-examples.md
@@ -15,7 +15,7 @@ commands.
 
 {{< /callout >}}
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 This isn't the actual page about custom commands. A brief overview about custom commands can be found in the
 [Custom Commands documentation](/docs/custom-commands/commands). Please take notice, some of examples presented here are not up to

--- a/content/docs/reference/custom-embeds.md
+++ b/content/docs/reference/custom-embeds.md
@@ -14,7 +14,7 @@ documentation](https://discord.com/developers/docs/resources/channel#embed-objec
 
 {{< /callout >}}
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Custom Embeds with the `-customembed` command don't work in custom commands. If you want to know how you can use embeds
 in custom commands, scroll down to [Embeds in Custom Commands](#embeds-in-custom-commands).
@@ -107,7 +107,7 @@ with a channel name or ID (or send the embed with sendDM as a direct message).&#
 
 Next, we'll take a look at this more lavish example:
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 To make your code readable, especially for large embeds, **indents** may be used, as YAGPDB's templating system allows this sort of formatting.
 
@@ -237,7 +237,7 @@ This generates the following embed:
 
 You can play around with this command a bit, it's really easy to use.&#x20;
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Simple embeds can be used in custom commands:
 

--- a/content/docs/reference/custom-embeds.md
+++ b/content/docs/reference/custom-embeds.md
@@ -7,14 +7,14 @@ A guide to creating custom embeds in various contexts across YAGPDB.
 
 <!--more-->
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 Embeds have limits, summarized in [Discord channel
 documentation](https://discord.com/developers/docs/resources/channel#embed-object-embed-limits).
 
 {{< /callout >}}
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Custom Embeds with the `-customembed` command don't work in custom commands. If you want to know how you can use embeds
 in custom commands, scroll down to [Embeds in Custom Commands](#embeds-in-custom-commands).
@@ -84,7 +84,7 @@ and the last curly brace (`}`). After this you can just copy and paste it into D
 
 ## Embeds in Custom Commands
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 Embeds in custom commands are a little more difficult. Also, there is no generator that you could use for this. **Please only proceed if you have a good amount of knowledge about custom commands and templates in general.**
 
@@ -107,7 +107,7 @@ with a channel name or ID (or send the embed with sendDM as a direct message).&#
 
 Next, we'll take a look at this more lavish example:
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 To make your code readable, especially for large embeds, **indents** may be used, as YAGPDB's templating system allows this sort of formatting.
 
@@ -237,7 +237,7 @@ This generates the following embed:
 
 You can play around with this command a bit, it's really easy to use.&#x20;
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Simple embeds can be used in custom commands:
 

--- a/content/docs/reference/custom-interactions.md
+++ b/content/docs/reference/custom-interactions.md
@@ -122,7 +122,7 @@ ID which can trigger a custom command.
 
 ##### Custom IDs
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Multiple buttons and menus can not have the same custom ID in one message.
 
@@ -233,7 +233,7 @@ Setting default values in these select menus is a more involved process than for
 
 ![The above mentionable menu with default options selected](mentionable_menu_with_defaults.png)
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 The `default_values` `id`s must be `string`s, not `int64`s. Note how in the above example, `$adminRoleID :=
 "1210128415689285642"` defining it as a string, as opposed to `$adminRoleID := 1210128415689285642` which would define
@@ -271,7 +271,7 @@ This gives us a select menu which we can only select guild announcement and guil
 
 Now, let's add some more buttons.
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Buttons with the "link" style cannot have a Custom ID, and instead require a URL field.
 

--- a/content/docs/reference/custom-interactions.md
+++ b/content/docs/reference/custom-interactions.md
@@ -7,7 +7,7 @@ Buttons, Modals, Select Menus, Ephemeral Messages, and more!
 
 <!--more-->
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 Use of interactions within YAGPDB is an advanced topic; you will need a thorough understanding of YAGPDB's scripting
 language before learning interactions.
@@ -122,7 +122,7 @@ ID which can trigger a custom command.
 
 ##### Custom IDs
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Multiple buttons and menus can not have the same custom ID in one message.
 
@@ -233,7 +233,7 @@ Setting default values in these select menus is a more involved process than for
 
 ![The above mentionable menu with default options selected](mentionable_menu_with_defaults.png)
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 The `default_values` `id`s must be `string`s, not `int64`s. Note how in the above example, `$adminRoleID :=
 "1210128415689285642"` defining it as a string, as opposed to `$adminRoleID := 1210128415689285642` which would define
@@ -271,7 +271,7 @@ This gives us a select menu which we can only select guild announcement and guil
 
 Now, let's add some more buttons.
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Buttons with the "link" style cannot have a Custom ID, and instead require a URL field.
 

--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -10,7 +10,7 @@ values you can send in your response or use as arguments for other functions.
 
 > Functions are underappreciated. In general, not just in templates. // Rob Pike
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Every function having both cases possible for an argument - ID/name, then this name is handled case insensitive, for
 example `getRole "yagpdb"` and `getRole "yAgPdB"` would have same responses even if server has both of these roles, so
@@ -20,7 +20,7 @@ using IDs is better.
 
 ### Channel
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 The ratelimit for editing a channel is 2 requests per 10 minutes per channel.
 
@@ -63,7 +63,7 @@ The ratelimit for editing a channel is 2 requests per 10 minutes per channel.
 Patterns are basic PostgreSQL patterns, not Regexp: An underscore `(_)` matches any single character; a percent sign
 `(%)` matches any sequence of zero or more characters.
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 **Note about saving numbers into database:** As stated above, database stores numbers as type _float64_. If you save a
 large number into database like an _int64_ (which IDs are), the value will be truncated. To avoid this behavior, you can
@@ -233,7 +233,7 @@ about using interactions, [see here](/docs/reference/custom-interactions).
 
 ### Math
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Boolean logic (and, not, or) and comparison operators (eq, gt, lt, etc.) are covered in [conditional
 branching](/docs/reference/templates/template-scripting#if-conditional-branching).
@@ -363,7 +363,7 @@ something nice - you all are doing awesome!" "filename" currentTime.Weekday)}}`
 
 ### Miscellaneous
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 `if`, `range`, `try-catch`, `while`, `with` actions are all covered on the [actions template documentation](/docs/reference/templates/template-scripting#actions).
 
@@ -401,7 +401,7 @@ something nice - you all are doing awesome!" "filename" currentTime.Weekday)}}`
 
 ### Role functions
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 In all role functions where userID is required as argument to target a user, it can also be full user object.
 
@@ -427,7 +427,7 @@ In all role functions where userID is required as argument to target a user, it 
 
 ### String manipulation
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 All regexp functions are limited to 10 different pattern calls per CC.
 
@@ -452,7 +452,7 @@ All regexp functions are limited to 10 different pattern calls per CC.
 | `upper` "string"                                     | Converts the string to uppercase.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `urlescape` "string"                                 | Escapes the _string_ so it can be safely placed inside a URL path segment - e.g. "Hello, YAGPDB!" becomes "Hello%2C%20YAGPDB%21"<br>There's also predefined template package function `urlquery` which is covered in [Go text/template documentation](https://pkg.go.dev/text/template#hdr-Functions).                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Special information we can include in the string is _escape sequences_. Escape sequences are two (or more) characters,
 the first of which is a backslash `\`, which gives the remaining characters special meaning - let's call them
@@ -460,7 +460,7 @@ metacharacters. The most common escape sequence you will encounter is `\n`, whic
 
 {{< /callout >}}
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 With regular expression patterns - when using quotes you have to "double-escape" metacharacters starting with backslash.
 You can use backquotes/ticks to simplify this:`{{reFind "\\d+" (toString 42)}}` versus `` {{reFind `\d+` (toString
@@ -495,7 +495,7 @@ You can use backquotes/ticks to simplify this:`{{reFind "\\d+" (toString 42)}}` 
 | `timestampToTime` arg                                  | Converts UNIX timestamp to _time.Time_. Example: \{{timestampToTime 1420070400\}} would return same time as `.DiscordEpoch`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `weekNumber` time                                      | Returns the week number as _int_ of given argument `time` of type _time.Time_. `{{weekNumber currentTime}}` would return the week number of current time.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Discord Timestamp Styles referenced on
 [Discord message documentation](https://discord.com/developers/docs/reference#message-formatting-timestamp-styles) can be done using `print`

--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -10,7 +10,7 @@ values you can send in your response or use as arguments for other functions.
 
 > Functions are underappreciated. In general, not just in templates. // Rob Pike
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Every function having both cases possible for an argument - ID/name, then this name is handled case insensitive, for
 example `getRole "yagpdb"` and `getRole "yAgPdB"` would have same responses even if server has both of these roles, so
@@ -20,7 +20,7 @@ using IDs is better.
 
 ### Channel
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 The ratelimit for editing a channel is 2 requests per 10 minutes per channel.
 
@@ -63,7 +63,7 @@ The ratelimit for editing a channel is 2 requests per 10 minutes per channel.
 Patterns are basic PostgreSQL patterns, not Regexp: An underscore `(_)` matches any single character; a percent sign
 `(%)` matches any sequence of zero or more characters.
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 **Note about saving numbers into database:** As stated above, database stores numbers as type _float64_. If you save a
 large number into database like an _int64_ (which IDs are), the value will be truncated. To avoid this behavior, you can
@@ -76,7 +76,7 @@ convert the number to type _string_ before saving and later back to its original
 
 ### ExecCC
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 `execCC` calls are limited to 1 / CC for non-premium users and 10 / CC for premium users.
 
@@ -109,7 +109,7 @@ convert the number to type _string_ before saving and later back to its original
 
 ### Interactions
 
-{{< callout context="tip" icon="outline/rocket" >}}
+{{< callout context="tip" title="Tip" icon="outline/rocket" >}}
 
 Use of interactions within YAGPDB is an advanced topic; the documentation should be used only as reference. To learn
 about using interactions, [see here](/docs/reference/custom-interactions).
@@ -233,7 +233,7 @@ about using interactions, [see here](/docs/reference/custom-interactions).
 
 ### Math
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Boolean logic (and, not, or) and comparison operators (eq, gt, lt, etc.) are covered in [conditional
 branching](/docs/reference/templates/template-scripting#if-conditional-branching).
@@ -363,7 +363,7 @@ something nice - you all are doing awesome!" "filename" currentTime.Weekday)}}`
 
 ### Miscellaneous
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 `if`, `range`, `try-catch`, `while`, `with` actions are all covered on the [actions template documentation](/docs/reference/templates/template-scripting#actions).
 
@@ -401,7 +401,7 @@ something nice - you all are doing awesome!" "filename" currentTime.Weekday)}}`
 
 ### Role functions
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 In all role functions where userID is required as argument to target a user, it can also be full user object.
 
@@ -427,7 +427,7 @@ In all role functions where userID is required as argument to target a user, it 
 
 ### String manipulation
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 All regexp functions are limited to 10 different pattern calls per CC.
 
@@ -452,7 +452,7 @@ All regexp functions are limited to 10 different pattern calls per CC.
 | `upper` "string"                                     | Converts the string to uppercase.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `urlescape` "string"                                 | Escapes the _string_ so it can be safely placed inside a URL path segment - e.g. "Hello, YAGPDB!" becomes "Hello%2C%20YAGPDB%21"<br>There's also predefined template package function `urlquery` which is covered in [Go text/template documentation](https://pkg.go.dev/text/template#hdr-Functions).                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Special information we can include in the string is _escape sequences_. Escape sequences are two (or more) characters,
 the first of which is a backslash `\`, which gives the remaining characters special meaning - let's call them
@@ -460,7 +460,7 @@ metacharacters. The most common escape sequence you will encounter is `\n`, whic
 
 {{< /callout >}}
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 With regular expression patterns - when using quotes you have to "double-escape" metacharacters starting with backslash.
 You can use backquotes/ticks to simplify this:`{{reFind "\\d+" (toString 42)}}` versus `` {{reFind `\d+` (toString
@@ -495,7 +495,7 @@ You can use backquotes/ticks to simplify this:`{{reFind "\\d+" (toString 42)}}` 
 | `timestampToTime` arg                                  | Converts UNIX timestamp to _time.Time_. Example: \{{timestampToTime 1420070400\}} would return same time as `.DiscordEpoch`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `weekNumber` time                                      | Returns the week number as _int_ of given argument `time` of type _time.Time_. `{{weekNumber currentTime}}` would return the week number of current time.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Discord Timestamp Styles referenced on
 [Discord message documentation](https://discord.com/developers/docs/reference#message-formatting-timestamp-styles) can be done using `print`
@@ -523,7 +523,7 @@ function e.g.
 - To demonstrate `toDuration`, outputs 12 hours from current time in UTC.\
   `{{(currentTime.Add (toDuration (mult 12 .TimeHour))).Format "15:04"}}`is the same as`{{(currentTime.Add (toDuration "12h")).Format "15:04"}}` or`{{(currentTime.Add (toDuration 43200000000000)).Format "15:04"}}`
 
-{{< callout context="tip" icon="outline/rocket" >}}
+{{< callout context="tip" title="Tip" icon="outline/rocket" >}}
 
 **Tip:** You can convert a Unicode code point back to its string equivalent using `printf "%c"`. For example, `printf
 "%c" 99` would result in the string `c` as `99` is the Unicode code point for `c`.`printf` is briefly covered later on

--- a/content/docs/reference/templates/template-scripting.md
+++ b/content/docs/reference/templates/template-scripting.md
@@ -28,7 +28,7 @@ usually denoted by 3-dot `...`ellipsis.&#x20;
 If functions or methods are denoted with an accent, tilde \~, they are not yet deployed in actual YAGPDB bot or have
 been disabled in main bot, but are in master code branch.
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 **Always put curly brackets around the data and "actions you perform" you want to formulate as a template** like
 this:`{{.User.Username}}`
@@ -38,7 +38,7 @@ structure also known as an action with methods and functions stated below.
 
 {{< /callout >}}
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Templating system uses standard ASCII quotation marks:\
 0x22 > `"` for straight double quotes, 0x27 > `'`for apostrophes and 0x60 `` ` `` for backticks/back quotes; so make
@@ -98,7 +98,7 @@ would be `{{ add 2 (randInt 41) }}`. Same pipeline but using a variable is also 
 not return anything as printout, 40 still goes through pipeline to addition and 42 is stored to variable `$x` whereas
 `{{($x:=40)| add 2}}` would return 42 and store 40 to `$x`.
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 Pipes are useful in select cases to shorten code and in some cases improve readability, but they **should not be
 overused**. In most cases, pipes are unnecessary and cause a dip in readability that helps nobody.
@@ -197,7 +197,7 @@ Similarly, provided a channel `$channel`, `$channel.Name` gives the name of the 
 
 ### Interaction
 
-{{< callout context="tip" icon="outline/rocket" >}}
+{{< callout context="tip" title="Tip" icon="outline/rocket" >}}
 
 Use of interactions within YAGPDB is an advanced topic; the documentation should be used only as reference. To learn
 about using interactions, please view our [interactions cookbook](/docs/reference/custom-interactions).
@@ -351,7 +351,7 @@ Branching using `if` action's pipeline and comparison operators - these operator
 `if` statements always need to have an enclosing `end`.\
 Learning resources covers conditional branching [more in depth](https://learn.yagpdb.xyz/beginner/control_flow_1).\
 
-{{< callout context="tip" icon="outline/rocket" >}}
+{{< callout context="tip" title="Tip" icon="outline/rocket" >}}
 
 `eq` , though often used with 2 arguments (`eq x y`) can actually be used with more than 2. If there are more than 2
 arguments, it checks whether the first argument is equal to any one of the following arguments. This behavior is unique
@@ -359,7 +359,7 @@ to `eq`.
 
 {{< /callout >}}
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Comparison operators always require the same type: i.e comparing `1.23` and `1` would throw **`incompatible types for
 comparison`** error as they are not the same type (one is float, the other int). To fix this, you should convert both to
@@ -379,7 +379,7 @@ the same type -> for example, `toFloat 1`.
 channels. The dot `.` is set to successive elements of those data structures and output will follow execution. If the
 value of pipeline has zero length, nothing is output or if an `{{else}}` action is used, that section will be executed.
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 To skip execution of a single iteration and jump to the next iteration, the `{{continue}}` action may be used. Likewise,
 if one wishes to skip all remaining iterations, the `{{break}}` action may be used. These both are usable also inside
@@ -414,7 +414,7 @@ Like `if`, `range`is concluded with`{{end}}`action and declared variable scope i
 {{ $x := 42 }} {{ range $x := seq 2 4 }} {{ $x }} {{ end }} {{ $x }}
 ```
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 **Custom command response was longer than 2k (contact an admin on the server...)**\
 or \
@@ -545,7 +545,7 @@ To define an associated template, use the `define` action. It has the following 
 {{ end }}
 ```
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 **Warning:** Template definitions must be at the top level of the custom command program; in other words, they cannot be
 nested in other actions (for example, an if action.) That is, the following custom command is invalid:
@@ -589,7 +589,7 @@ an associated template that always returns `1`:
 
 Note that it is not necessary for a value to be returned; `{{ return }}` by itself is completely valid.
 
-{{< callout context="tip" icon="outline/rocket" >}}
+{{< callout context="tip" title="Tip" icon="outline/rocket" >}}
 
 **Note:** Since all custom commands are themselves templates, using a `return` action at the top level is perfectly
 valid, and will result in execution of the custom command being stopped at the point the `return` is encountered.
@@ -615,7 +615,7 @@ To execute a custom command, one of three methods may be used: `template`, `bloc
 value. Note that the name of the template to execute must be a string constant; similar to `define` actions, a variable
 referencing a value of string type is invalid. Data to use as the context may optionally be provided following the name.
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 While `template` is function-like, it is not an actual function, leading to certain quirks; notably, it must be used
 alone, not part of another action (like a variable declaration), and the data argument need not be parenthesized. Due to
@@ -691,7 +691,7 @@ _templates.SDict_ (abridged to _sdict_) types and their methods. Both types hand
 called an empty interface which allows a value to be of any type. So any argument of any type given is handled. (In
 "custom commands"-wise mainly primitive data types, but _slices_ as well.)
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 **Reference type-like behavior:** Slices and dictionaries in CCs exhibit reference-type like behavior, which may be
 undesirable in certain situations. That is, if you have a variable `$x` that holds a slice/dictionary, writing `$y :=
@@ -789,7 +789,7 @@ Adding "color3" as "blue": {{ $x.Set "color3" "blue" }} **{{ $x }}**
 Deleting key "color1" {{ $x.Del "color1" }} and whole sdict: **{{ $x }}**
 ```
 
-{{< callout context="tip" icon="outline/rocket" >}}
+{{< callout context="tip" title="Tip" icon="outline/rocket" >}}
 
 **Tip:** Previously, when saving cslices, sdicts, and dicts into database, they were serialized into their underlying
 native types - slices and maps. This meant that if you wanted to get the custom type back, you needed to convert
@@ -842,7 +842,7 @@ Learning resources covers database [more in-depth](https://learn.yagpdb.xyz/inte
 
 ## Tickets
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 Ticket functions are limited to 1 call per custom command for both normal and premium guilds and limited to max 10 open
 tickets per user.

--- a/content/docs/reference/templates/template-scripting.md
+++ b/content/docs/reference/templates/template-scripting.md
@@ -38,7 +38,7 @@ structure also known as an action with methods and functions stated below.
 
 {{< /callout >}}
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Templating system uses standard ASCII quotation marks:\
 0x22 > `"` for straight double quotes, 0x27 > `'`for apostrophes and 0x60 `` ` `` for backticks/back quotes; so make
@@ -359,7 +359,7 @@ to `eq`.
 
 {{< /callout >}}
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Comparison operators always require the same type: i.e comparing `1.23` and `1` would throw **`incompatible types for
 comparison`** error as they are not the same type (one is float, the other int). To fix this, you should convert both to
@@ -379,7 +379,7 @@ the same type -> for example, `toFloat 1`.
 channels. The dot `.` is set to successive elements of those data structures and output will follow execution. If the
 value of pipeline has zero length, nothing is output or if an `{{else}}` action is used, that section will be executed.
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 To skip execution of a single iteration and jump to the next iteration, the `{{continue}}` action may be used. Likewise,
 if one wishes to skip all remaining iterations, the `{{break}}` action may be used. These both are usable also inside
@@ -615,7 +615,7 @@ To execute a custom command, one of three methods may be used: `template`, `bloc
 value. Note that the name of the template to execute must be a string constant; similar to `define` actions, a variable
 referencing a value of string type is invalid. Data to use as the context may optionally be provided following the name.
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 While `template` is function-like, it is not an actual function, leading to certain quirks; notably, it must be used
 alone, not part of another action (like a variable declaration), and the data argument need not be parenthesized. Due to

--- a/content/docs/tools-and-utilities/autorole.md
+++ b/content/docs/tools-and-utilities/autorole.md
@@ -5,14 +5,14 @@ weight = 1
 
 <!--more-->
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Make sure that the bot has permission to manage roles **and** that the role the bot is assigning is below the highest
 role the bot has.
 
 {{< /callout >}}
 
-{{< callout context="caution" icon="outline/alert-triangle" >}}
+{{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
 
 **Warning:** Be careful when using autorole to automatically give new members roles. Discord's in-built new member
 verification only works on members with no roles, rendering it useless if members are given roles right after they

--- a/content/docs/tools-and-utilities/autorole.md
+++ b/content/docs/tools-and-utilities/autorole.md
@@ -5,7 +5,7 @@ weight = 1
 
 <!--more-->
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Make sure that the bot has permission to manage roles **and** that the role the bot is assigning is below the highest
 role the bot has.

--- a/content/docs/tools-and-utilities/self-assignable-roles.md
+++ b/content/docs/tools-and-utilities/self-assignable-roles.md
@@ -43,7 +43,7 @@ Do **not** set the require role to the role you are assigning. You generally wil
 
 ## Role Groups
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Role groups are essential if you want to set up a role menu.
 
@@ -94,7 +94,7 @@ To fix these problems we can create a new group with the mode `Single` and assig
 
 ### Adding roles to the role group
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Roles can only be assigned to one group.
 
@@ -114,7 +114,7 @@ The role menu makes it possible to have people assign roles by adding reactions 
 
 ![Example of a role menu](rolemenu_example.png)
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 If you'd like to create a message like the above to create a rolemenu on, take a look at the [Custom Embeds](/docs/reference/custom-embeds) chapter.
 
@@ -204,7 +204,7 @@ If you added a new role to your role group, you can update your role menu. Updat
 
 ## How to get a message ID (Desktop)
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 Make sure you have [developer mode turned on in your discord settings.](https://support.discordapp.com/hc/en-us/articles/206346498)&#x20;
 

--- a/content/docs/tools-and-utilities/self-assignable-roles.md
+++ b/content/docs/tools-and-utilities/self-assignable-roles.md
@@ -13,13 +13,13 @@ weight = 2
 
 ## Roles
 
-{{< callout context="caution" icon="outline/alert-triangle" >}}
+{{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
 
 Make sure that the bot has the _manage role_ permission and that the bot's role is **above** the role it is trying to assign.
 
 {{< /callout >}}
 
-{{< callout context="caution" icon="outline/alert-triangle" >}}
+{{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
 
 If you want to use any of the `rolemenu` commands, you **need** to have the `MANAGE_GUILD` permission, or the Manage Server permission. This is hardcoded, meaning that command overrides will not affect it.
 
@@ -31,7 +31,7 @@ Simply give the role command a name and then select which role you want the bot 
 
 ### Optional features
 
-{{< callout context="caution" icon="outline/alert-triangle" >}}
+{{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
 
 Do **not** set the require role to the role you are assigning. You generally will not want to set the ignore role to the role you are assigning either _unless_ you wish to prevent the user from removing that role through the role-menu.
 
@@ -43,7 +43,7 @@ Do **not** set the require role to the role you are assigning. You generally wil
 
 ## Role Groups
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Role groups are essential if you want to set up a role menu.
 
@@ -63,7 +63,7 @@ Every role group, even Ungrouped has the option to delete all roles inside that 
 
 ### Optional features
 
-{{< callout context="caution" icon="outline/alert-triangle" >}}
+{{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
 
 Do **not** set the require role to the role you are assigning. You generally will not want to set the ignore role to the role you are assigning either _unless_ you wish to prevent the user from removing that role through the rolemenu.
 
@@ -94,7 +94,7 @@ To fix these problems we can create a new group with the mode `Single` and assig
 
 ### Adding roles to the role group
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Roles can only be assigned to one group.
 
@@ -104,7 +104,7 @@ Refer back to the [optional features](#optional-features) for roles and select t
 
 ## Role Menu
 
-{{< callout context="caution" icon="outline/alert-triangle" >}}
+{{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
 
 Make sure you created your [role commands](#roles) and assigned them a [role group](#role-groups) before starting. Role menu will **not** work if you have not done so.
 
@@ -114,13 +114,13 @@ The role menu makes it possible to have people assign roles by adding reactions 
 
 ![Example of a role menu](rolemenu_example.png)
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 If you'd like to create a message like the above to create a rolemenu on, take a look at the [Custom Embeds](/docs/reference/custom-embeds) chapter.
 
 {{< /callout >}}
 
-{{< callout context="caution" icon="outline/alert-triangle" >}}
+{{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
 
 A role menu can only support up to 20 roles due to the reaction limit discord places on messages. If your role group has more then twenty you have to use finish sub-command and then add the rest of roles to a new message with -skip flag.
 
@@ -134,7 +134,7 @@ After you type in the command, you will be taken through the setup process. If y
 
 ### Step by step tutorial
 
-{{< callout context="caution" icon="outline/alert-triangle" >}}
+{{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
 
 Make sure you created your [role commands](#roles) and assigned them a [role group](#role-groups) before starting. Role menu will **not** work if you have not done so. All switches and flags (nodm, rr, etc...) start with hyphen symbol `-`, not your prefix.
 
@@ -172,7 +172,7 @@ After you have finish editing or creating your role menu, it will display whethe
 
 ![Rolemenu flags display](rolemenu_flags.png)
 
-{{< callout context="caution" icon="outline/alert-triangle" >}}
+{{< callout context="caution" title="Warning" icon="outline/alert-triangle" >}}
 
 Note that YAGPDB does not allow you to disable warning DMs such as cool-down messages with the `nodm` switch or any other method.
 
@@ -204,7 +204,7 @@ If you added a new role to your role group, you can update your role menu. Updat
 
 ## How to get a message ID (Desktop)
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 Make sure you have [developer mode turned on in your discord settings.](https://support.discordapp.com/hc/en-us/articles/206346498)&#x20;
 

--- a/content/docs/welcome/getting-started.md
+++ b/content/docs/welcome/getting-started.md
@@ -7,7 +7,7 @@ weight = 2
 
 ## Adding The Bot
 
-{{< callout context="info" title="Note" icon="outline/info-circle" >}}
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
 
 You need to have the **Manage Server** permission to add the bot to your server.
 

--- a/content/docs/welcome/getting-started.md
+++ b/content/docs/welcome/getting-started.md
@@ -7,7 +7,7 @@ weight = 2
 
 ## Adding The Bot
 
-{{< callout context="note" icon="outline/info-circle" >}}
+{{< callout context="info" title="Note" icon="outline/info-circle" >}}
 
 You need to have the **Manage Server** permission to add the bot to your server.
 

--- a/content/docs/welcome/premium.md
+++ b/content/docs/welcome/premium.md
@@ -72,7 +72,7 @@ A premium server unlocks the following benefits:
 
 - Increase maximum YouTube feeds per guild from 50 to 250 (`GuildMaxFeedsPremium`).
 
-{{< callout context="caution" icon="outline/alert-octagon" >}}
+{{< callout context="danger" title="Danger" icon="outline/alert-octagon" >}}
 
 Some features enhanced or enabled by premium have been disabled on Botlabs' publicly hosted instance, often due to
 ratelimits with 3rd party APIs YAGPDB relies on.


### PR DESCRIPTION
Standardize all callouts' contexts, titles, and icons using the
workspace snippets as a guide.

- Callouts previously using the "note" context now use the note
snippet.
- Caution callouts previously using the octagon icon now use the
danger snippet.

**Terms**
- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
