### PR TITLE
all: unify page descriptions to use frontmatter

### DIFF
--- a/content/docs/core/all-commands.md
+++ b/content/docs/core/all-commands.md
@@ -1,11 +1,10 @@
 +++
-title = 'All Commands'
+title = "All Commands"
 weight = 240
+description = "List of all available commands offered by YAGPDB and their syntax."
 +++
 
 List of all available commands offered by YAGPDB and their syntax.
-
-<!--more-->
 
 ## Legend
 

--- a/content/docs/core/command-settings.md
+++ b/content/docs/core/command-settings.md
@@ -1,11 +1,10 @@
 +++
-title = 'Command Settings'
+title = "Command Settings"
 weight = 230
+description = "Configure command overrides to restrict access to YAGPDB commands and optional autodelete intervals."
 +++
 
-Fine-grained control over all of YAGPDB's inbuilt commands.
-
-<!--more-->
+Fine-grained control over all of YAGPDB's inbuild commands.
 
 ## Overview
 

--- a/content/docs/core/control-panel-access.md
+++ b/content/docs/core/control-panel-access.md
@@ -1,11 +1,8 @@
 +++
-title = 'Control Panel Access'
+title = "Control Panel Access"
 weight = 210
+description = "Select who can view or edit your control panel."
 +++
-
-Select who can view or edit your control panel.
-
-<!--more-->
 
 This page is relatively simple, yet very powerful. An overview of the settings follows.
 

--- a/content/docs/core/control-panel-logs.md
+++ b/content/docs/core/control-panel-logs.md
@@ -1,11 +1,8 @@
 +++
-title = 'Control Panel Logs'
+title = "Control Panel Logs"
 weight = 220
+description = "View a list of recent changes to your YAGPDB configuration."
 +++
-
-View a list of recent changes to your YAGPDB configuration.
-
-<!--more-->
 
 This page is the analogue of the audit log built in to Discord for YAGPDB settings and summarizes recent edits on the
 control panel, listing the time, action, and responsible user for each. It is useful to audit who may be responsible if

--- a/content/docs/custom-commands/commands.md
+++ b/content/docs/custom-commands/commands.md
@@ -1,12 +1,11 @@
 +++
-title = 'Commands'
+title = "Commands"
 weight = 310
+description = "Custom command settings and editor."
 +++
 
 The commands page displays all custom commands and allows you to add, delete, or edit custom commands and custom command
 groups.
-
-<!--more-->
 
 ![Overview of the Commands page.](command_overview.png)
 

--- a/content/docs/custom-commands/database.md
+++ b/content/docs/custom-commands/database.md
@@ -1,12 +1,11 @@
 +++
-title = 'Database'
+title = "Database"
 weight = 320
+description = "See what's in your custom command database."
 +++
 
 The Custom Command Database is used for persistent storage between custom command executions. The database page displays
 all database entries created by custom commands, allowing you to view details on or delete individual entries.
-
-<!--more-->
 
 ![Overview of the Database page.](overview_database.png)
 

--- a/content/docs/fun/reputation.md
+++ b/content/docs/fun/reputation.md
@@ -1,12 +1,11 @@
 +++
-title = 'Reputation'
+title = "Reputation"
 weight = 810
+description = "Track and manage reputation points for users."
 +++
 
 The reputation system tracks each user's reputation score, and allows users to add or remove reputation points from
 other users.
-
-<!--more-->
 
 ## Setup
 

--- a/content/docs/fun/soundboard.md
+++ b/content/docs/fun/soundboard.md
@@ -1,11 +1,10 @@
 +++
-title = 'Soundboard'
+title = "Soundboard"
 weight = 820
+description = "Play sounds in voice channels with the soundboard system."
 +++
 
 The soundboard system allows the bot to join a voice channel, and play sounds triggered by soundboard commands.
-
-<!--more-->
 
 ## Uploading New Sounds
 

--- a/content/docs/moderation/basic-automoderator.md
+++ b/content/docs/moderation/basic-automoderator.md
@@ -1,11 +1,8 @@
 +++
-title = 'Basic Automoderator'
+title = "Basic Automoderator"
 weight = 420
+description = "A very basic automoderator to get things done quickly."
 +++
-
-A very basic automoderator to get things done quickly.
-
-<!--more-->
 
 ## Intro
 

--- a/content/docs/moderation/logging.md
+++ b/content/docs/moderation/logging.md
@@ -1,6 +1,7 @@
 +++
-title = 'Logging'
+title = "Logging"
 weight = 440
+description = "On-demand message logging."
 +++
 
 Capture a moment in time with message logging of the last messages in a channel when the log is created, including a

--- a/content/docs/moderation/moderation-tools.md
+++ b/content/docs/moderation/moderation-tools.md
@@ -1,11 +1,10 @@
 +++
 title = "Moderation Tools"
 weight = 410
+description = "Everything in moderation, including moderation."
 +++
 
 Everything in moderation, including moderation.
-
-<!--more-->
 
 ![Overview of the moderation page](overview_moderation.png)
 

--- a/content/docs/moderation/verification.md
+++ b/content/docs/moderation/verification.md
@@ -1,11 +1,10 @@
 +++
-title = 'Verification'
+title = "Verification"
 weight = 450
+description = "Google reCAPTCHA v2 verification for new members."
 +++
 
 Use Google reCAPTCHA v2 to verify your members before permitting them access to your server.
-
-<!--more-->
 
 ![Default Verification Page](page_verification.png)
 

--- a/content/docs/notifications/general.md
+++ b/content/docs/notifications/general.md
@@ -1,12 +1,11 @@
 +++
-title = 'General'
+title = "General"
 weight = 510
+description = "Welcome new users, announce when users leave, and more."
 +++
 
 General notifications such as a welcoming direct message, a message in the server when users join or leave, as well as a
 simple message announcing when a channel's topic has changed.
-
-<!--more-->
 
 ![Overview of general feeds](./general_overview.png)
 

--- a/content/docs/notifications/reddit.md
+++ b/content/docs/notifications/reddit.md
@@ -1,6 +1,7 @@
 +++
-title = 'Reddit'
+title = "Reddit"
 weight = 520
+description = "Stalk Reddit without actually using Reddit."
 +++
 
 Get notifications from your favorite subreddits directly in your Discord server.

--- a/content/docs/notifications/streaming.md
+++ b/content/docs/notifications/streaming.md
@@ -1,11 +1,11 @@
 +++
-title = 'Streaming'
+title = "Streaming"
 weight = 540
+description = "Spam your server with notifications when someone starts streaming."
 +++
 
 Let everyone know that someone is currently streaming.
 
-<!--more-->
 
 ### Streaming Feed
 

--- a/content/docs/notifications/youtube.md
+++ b/content/docs/notifications/youtube.md
@@ -1,6 +1,7 @@
 +++
-title = 'YouTube'
+title = "YouTube"
 weight = 530
+description = "Subscribe to your favorite YouTubers without polluting your own feed."
 +++
 
 Get notifications from your favorite YouTubers directly in your Discord server.

--- a/content/docs/reference/custom-command-examples.md
+++ b/content/docs/reference/custom-command-examples.md
@@ -1,6 +1,7 @@
 +++
-title = 'Custom Commands Examples'
+title = "Custom Commands Examples"
 weight = 920
+description = "Copy-and-paste code, \"for education purposes only\"."
 +++
 
 Prebuilt custom commands for use as a learning reference.

--- a/content/docs/reference/custom-commands-limits.md
+++ b/content/docs/reference/custom-commands-limits.md
@@ -1,11 +1,10 @@
 +++
-title = 'Custom Commands Limits'
+title = "Custom Commands Limits"
 weight = 930
+description = "Limits? I'm at my limit!"
 +++
 
 Various limits in YAGPDB custom commands (CC) for smooth functioning of the bot and misuse prevention.
-
-<!--more-->
 
 ## OVERALL
 

--- a/content/docs/reference/custom-embeds.md
+++ b/content/docs/reference/custom-embeds.md
@@ -1,6 +1,7 @@
 +++
-title = 'Custom Embeds'
+title = "Custom Embeds"
 weight = 940
+description = "Be fancy, use embeds!"
 +++
 
 A guide to creating custom embeds in various contexts across YAGPDB.

--- a/content/docs/reference/custom-interactions.md
+++ b/content/docs/reference/custom-interactions.md
@@ -1,6 +1,7 @@
 +++
-title = 'Custom Interactions'
+title = "Custom Interactions"
 weight = 950
+description = "Even better than embeds!"
 +++
 
 Buttons, Modals, Select Menus, Ephemeral Messages, and more!

--- a/content/docs/reference/how-to-get-ids.md
+++ b/content/docs/reference/how-to-get-ids.md
@@ -1,11 +1,10 @@
 +++
-title = 'How to Get IDs'
+title = "How to Get IDs"
 weight = 960
+description = "Snowflake? ID? I don't know, but this page does!"
 +++
 
 Details on obtaining IDs for users, channels, roles, etc. for use within YAGPDB.
-
-<!--more-->
 
 **User IDs:** Can be found by mentioning the user then adding a \ such as `\@YAGPDB.xyz#8760` . Alternatively if you have developer mode on, you can right click and select Copy ID. [How to enable developer mode in Discord](https://support.discordapp.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-).
 

--- a/content/docs/reference/regex.md
+++ b/content/docs/reference/regex.md
@@ -1,6 +1,7 @@
 +++
-title = 'Using RegEx'
+title = "Using RegEx"
 weight = 970
+description = "s/regex/dark voodoo/i"
 +++
 
 A quick overview of golang flavored RegEx for your convenience.

--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -1,12 +1,11 @@
 +++
-title = 'Functions'
+title = "Functions"
 weight = 912
+description = "A list of all available functions in YAGPDB's custom command templates."
 +++
 
 Functions are used to take action within template scripts. Some functions accept arguments, and some functions return
 values you can send in your response or use as arguments for other functions.
-
-<!--more-->
 
 ----
 

--- a/content/docs/reference/templates/syntax-and-data.md
+++ b/content/docs/reference/templates/syntax-and-data.md
@@ -1,11 +1,10 @@
 +++
 title = "Syntax and Data"
 weight = 911
+description = "Available data in custom commands and a quick syntax refresher."
 +++
 
 Library of base data accessible within custom scripting.
-
-<!--more-->
 
 > "Go is all about type... Type is life." // William Kennedy
 

--- a/content/docs/tools-and-utilities/autorole.md
+++ b/content/docs/tools-and-utilities/autorole.md
@@ -1,9 +1,9 @@
 +++
-title = 'Autorole'
+title = "Autorole"
 weight = 710
+description = "Automatically assign roles to members when they join."
 +++
 
-<!--more-->
 
 {{< callout context="note" title="Note" icon="outline/info-circle" >}}
 

--- a/content/docs/tools-and-utilities/self-assignable-roles.md
+++ b/content/docs/tools-and-utilities/self-assignable-roles.md
@@ -1,6 +1,7 @@
 +++
-title = 'Self Assignable Roles'
+title = "Self Assignable Roles"
 weight = 720
+description = "how2 reaction role"
 +++
 
 <!--more-->

--- a/content/docs/tools-and-utilities/tickets.md
+++ b/content/docs/tools-and-utilities/tickets.md
@@ -1,9 +1,8 @@
 +++
-title = 'Tickets'
+title = "Tickets"
 weight = 730
+description = "No ticket no entry"
 +++
-
-<!--more-->
 
 Tickets let your members interact with your server staff in a private and more organized way. The bot will create a
 dedicated channel that can only be seen by the staff and the member who created the ticket, with the option to add more

--- a/content/docs/welcome/getting-started.md
+++ b/content/docs/welcome/getting-started.md
@@ -1,6 +1,7 @@
 +++
 title = "Getting Started"
 weight = 120
+description = "The first steps to setting up YAGPDB on your server."
 +++
 
 > The hardest thing about getting started, is getting started. - Guy Kawasaki

--- a/content/docs/welcome/introduction.md
+++ b/content/docs/welcome/introduction.md
@@ -1,6 +1,7 @@
 +++
 title = "Introduction"
 weight = 110
+description = "Start here!"
 +++
 
 > Documentation is for users. - Rob Pike

--- a/content/docs/welcome/premium.md
+++ b/content/docs/welcome/premium.md
@@ -1,6 +1,7 @@
 +++
 title = "Premium"
 weight = 130
+description = "Unlock additional features and functionality by supporting YAGPDB."
 +++
 
 YAGPDB provides added functionality to servers which are assigned a premium slot by a user. On the official instance of

--- a/content/learn/beginner/command-arguments.md
+++ b/content/learn/beginner/command-arguments.md
@@ -1,6 +1,7 @@
 +++
 title = "Command Arguments"
 weight = 240
+description = "Learn how to parse and validate arguments for custom commands."
 +++
 
 When we were starting to write Custom Commands, we stuck to a somewhat static custom command---one that doesn't take

--- a/content/learn/beginner/conditional-branching.md
+++ b/content/learn/beginner/conditional-branching.md
@@ -1,6 +1,7 @@
 +++
 title = "Conditional Branching"
 weight = 230
+description = "Learn how to make decisions in your custom commands using control flow."
 +++
 
 Until now, we have just written some linear code that executes from top to bottom. However, in real-world applications,

--- a/content/learn/beginner/simple-responses.md
+++ b/content/learn/beginner/simple-responses.md
@@ -1,6 +1,7 @@
 +++
 title = "Simple Responses"
 weight = 210
+description = "Learn how to get YAGPDB to say something!"
 +++
 
 In this chapter, we will go over two ways to output text from a custom command: using the _response_, and later on using

--- a/content/learn/beginner/variables-and-data-types.md
+++ b/content/learn/beginner/variables-and-data-types.md
@@ -1,6 +1,7 @@
 +++
 title = "Variables and Data Types"
 weight = 220
+description = "Learn how to store data in variables and the basic data types available."
 +++
 
 In this chapter, we will overview how to store data in variables and the basic data types available, which include

--- a/content/learn/intermediate/database.md
+++ b/content/learn/intermediate/database.md
@@ -1,6 +1,7 @@
 +++
 title = "Database"
 weight = 340
+description = "Learn how to store data across time and space with YAGPDB."
 +++
 
 YAGPDB provides a database for use in your CCs. Entries in this database are used to store persistent data that you want

--- a/content/learn/intermediate/embeds-and-messages.md
+++ b/content/learn/intermediate/embeds-and-messages.md
@@ -1,6 +1,7 @@
 +++
 title = "Embeds and Messages"
 weight = 310
+description = "Learn how to send messages to different channels, edit existing messages, and send messages with embeds."
 +++
 
 Until now, we have just used the [default response behavior](/learn/beginner/simple-responses) to make our custom

--- a/content/learn/intermediate/exercises.md
+++ b/content/learn/intermediate/exercises.md
@@ -1,6 +1,7 @@
 +++
 title = "Exercises"
 weight = 350
+description = "Exercise your skills with these custom command challenges."
 +++
 
 Below are some exercises to help you practice and reinforce your understanding of the concepts discussed in the previous

--- a/content/learn/intermediate/loops.md
+++ b/content/learn/intermediate/loops.md
@@ -1,6 +1,7 @@
 +++
 title = "Loops"
 weight = 330
+description = "Brother do you have some Loops?"
 +++
 
 In a previous chapter, we learned about [conditional branching](/learn/beginner/conditional-branching).

--- a/content/learn/intermediate/maps-and-slices.md
+++ b/content/learn/intermediate/maps-and-slices.md
@@ -1,6 +1,7 @@
 +++
 title = "Maps and Slices"
 weight = 320
+description = "No, we don't mean roadmaps or cake slices, but they are a piece of cake nevertheless!"
 +++
 
 When you first started this course, you learned about [primitive data types](/learn/beginner/variables-and-data-types).

--- a/content/learn/welcome/introduction.md
+++ b/content/learn/welcome/introduction.md
@@ -1,6 +1,7 @@
 +++
 title = "Introduction"
 weight = 110
+description = "Learn how to write custom commands for YAGPDB."
 +++
 
 > The first thing you gotta discard, whenever you're learning about something, is your ego. - Luke Smith


### PR DESCRIPTION
Unify all page descriptions to use the TOML frontmatter instead of the
magic `<!--more-->` comment, allowing for funny tidbits that are hidden
on the page.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
