### PR TITLE
reference: improve accuracy of closeThread desc

### DIFF
--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -33,9 +33,9 @@ Adds a member to an existing thread. Does nothing if either argument is invalid.
 {{ closeThread <thread> <lock> }}
 ```
 
-Closes the given thread.
+Closes or locks the given thread. You cannot lock a closed thread, but you can close a locked thread.
 
-- `lock`: whether to also lock the thread. Default `false`.
+- `lock`: whether to lock the thread instead. Default `false`.
 
 #### createForumPost
 


### PR DESCRIPTION
`closeThread` does not archive a thread if the lock flag is provided. It will do one or the other. Also adds a hint for
users who'd like to do both that they should lock before closing.

**Terms**
- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>