### PR TITLE
reference/functions: correct carg duration min max

### DIFF
--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -2289,7 +2289,7 @@ An argument's `"type"` must be one of the following:
   duration)
 
 Additionally, the `int`, `float`, and `duration` type support validation ranges in the interval `(min, max)`, where for
-`duration` it is in seconds.
+`duration` it is in nanoseconds, or simply pass [time.Duration format](/docs/reference/templates/syntax-and-data#time) values.
 
 ##### Example
 

--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -2289,7 +2289,7 @@ An argument's `"type"` must be one of the following:
   duration)
 
 Additionally, the `int`, `float`, and `duration` type support validation ranges in the interval `(min, max)`, where for
-`duration` it is in nanoseconds, or simply pass [time.Duration format](/docs/reference/templates/syntax-and-data#time) values.
+`duration` it is in [time.Duration format](/docs/reference/templates/syntax-and-data#time) values.
 
 ##### Example
 

--- a/content/learn/beginner/command-arguments.md
+++ b/content/learn/beginner/command-arguments.md
@@ -133,7 +133,7 @@ Following types support these validation ranges:
 
 - `int`
 - `float`
-- `duration` (in seconds)
+- `duration` (in [time.Duration format](/docs/reference/templates/syntax-and-data#time))
 
 Make sure to use these instead of manually verifying a valid range, if possible, as it makes your code cleaner and
 easier to read.


### PR DESCRIPTION
Correct the format the `min` and `max` values for a `duration` type `carg` accept.

**Terms**
- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
