### PR TITLE
added forwards to the complexMessage Section

### DIFF
--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -1215,7 +1215,7 @@ Creates a complex message object for use in [sendMessage](#sendmessage) function
 - `menus`: a single [select menu object](#cmenu).
 - `buttons`: a slice of [button objects](#cbutton).
 - `sticker`: single sticker ID or a slice of sticker IDs
-- `forward`: must contain an sdict with a channel and message value
+- `forward`: an sdict containing `channel` and `message` keys specifying the message to forward
 
 All of these keys are optional, but providing an empty content, file, or no embeds will result in no message being sent.
 
@@ -1265,7 +1265,7 @@ Example of a message forward:
 {{ sendMessage nil (complexMessage
     "forward" (sdict
         "channel" .Channel.ID
-        "message" <messageID>
+        "message" .Message.ID
     )
 ) }}
 ```

--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -1196,7 +1196,7 @@ for an example.
 #### complexMessage
 
 ```yag
-{{ $message := complexMessage [allowed_mentions] [content] [embed] [file] [filename] [reply] [silent] [menus] [buttons]  }}
+{{ $message := complexMessage [allowed_mentions] [content] [embed] [file] [filename] [reply] [silent] [menus] [buttons] [forward] }}
 ```
 
 Creates a complex message object for use in [sendMessage](#sendmessage) functions.
@@ -1214,6 +1214,7 @@ Creates a complex message object for use in [sendMessage](#sendmessage) function
 - `silent`: whether to suppress push and desktop notifications.
 - `menus`: a single [select menu object](#cmenu).
 - `buttons`: a slice of [button objects](#cbutton).
+- `forward`: must contain an sdict with a channel and message value
 
 All of these keys are optional, but providing an empty content, file, or no embeds will result in no message being sent.
 
@@ -1239,6 +1240,17 @@ the triggering message and ping the author of that message, but suppress the res
   "silent" true
 }}
 {{ sendMessage nil $message }}
+```
+
+Example of a message forward:
+
+```yag
+{{ sendMessage nil (complexMessage
+    "forward" (sdict
+        "channel" .Channel.ID
+        "message" <messageID>
+    )
+) }}
 ```
 
 #### deleteAllMessageReactions


### PR DESCRIPTION
<!-- Please describe the changes this pull request does and why it should be merged -->
I added message forward information to the complexMessage function based on information from the commit: https://github.com/botlabs-gg/yagpdb/pull/1764 
**Terms**
- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)

Signed off by: savage4618 <randomdad@randomdad.xyz>