### PR TITLE
tmpl: correct println description

### DIFF
--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -1722,7 +1722,7 @@ Concatenates the arguments in order, adding spaces between arguments when neithe
 {{ $result := println <args...> }}
 ```
 
-Concatenates the arguments in order, adding spaces between arguments when neither is a string and inserting a newline at
+Concatenates the arguments in order, adding spaces between arguments and inserting a newline at
 the end.
 
 #### printf


### PR DESCRIPTION
> Spaces are always added between operands and a newline is appended.

`println` *always* inserts spaces within arguments, as defined in the
godoc: https://pkg.go.dev/fmt#Sprintln

Signed-off-by: Galen CC <galen8183@gmail.com>

**Terms**
- [X] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
