### PR TITLE
Reference: in(Fold) Description and Reorder

### DIFF
--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -2221,14 +2221,6 @@ Places commas to separate groups of thousands in a number.
 
 - `number`: the number to format. Must be an int or a string. Must be a whole number.
 
-#### inFold
-
-```yag
-{{ $result := inFold <list> <value> }}
-```
-
-Same as [in](#in), but is case-insensitive. List can be a slice or string.
-
 #### in
 
 ```yag
@@ -2236,6 +2228,14 @@ Same as [in](#in), but is case-insensitive. List can be a slice or string.
 ```
 
 Returns whether the case-sensitive `value` is in the provided list. List can be a slice or string.
+
+#### inFold
+
+```yag
+{{ $result := inFold <list> <value> }}
+```
+
+Same as [in](#in), but is case-insensitive. List can be a slice or string.
 
 #### index
 

--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -2234,6 +2234,7 @@ Returns whether the case-sensitive `value` is in the `sequence`. `sequence` can 
 ```yag
 {{ $result := inFold <sequence> <value> }}
 ```
+
 Same as [in](#in), but is case-insensitive. `sequence` can be a slice or string.
 
 #### index

--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -2224,18 +2224,17 @@ Places commas to separate groups of thousands in a number.
 #### in
 
 ```yag
-{{ $result := in <list> <value> }}
+{{ $result := in <sequence> <value> }}
 ```
 
-Returns whether the case-sensitive `value` is in the provided list. List can be a slice or string.
+Returns whether the case-sensitive `value` is in the `sequence`. `sequence` can be a slice or string.
 
 #### inFold
 
 ```yag
-{{ $result := inFold <list> <value> }}
+{{ $result := inFold <sequence> <value> }}
 ```
-
-Same as [in](#in), but is case-insensitive. List can be a slice or string.
+Same as [in](#in), but is case-insensitive. `sequence` can be a slice or string.
 
 #### index
 

--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -2227,7 +2227,7 @@ Places commas to separate groups of thousands in a number.
 {{ $result := inFold <list> <value> }}
 ```
 
-Same as [in](#in), but is case-insensitive.
+Same as [in](#in), but is case-insensitive. List can be a slice or string.
 
 #### in
 
@@ -2235,7 +2235,7 @@ Same as [in](#in), but is case-insensitive.
 {{ $result := in <list> <value> }}
 ```
 
-Returns whether the case-sensitive `value` is in the provided list.
+Returns whether the case-sensitive `value` is in the provided list. List can be a slice or string.
 
 #### index
 


### PR DESCRIPTION
<!-- Please describe the changes this pull request does and why it should be merged -->

This PR adds to the description of the `in` and `inFold` functions of custom command reference to specify the first argument of the functions can be a slice or string.
This PR also reorders the mentioned functions so that `inFold` follows `in`, which both allows `inFold`'s description to base off of `in`'s description and follows the order as seen with the `reFind` family of functions.

**Terms**

- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
