### PR TITLE
docs(functions): Missing sort and printf functions

### DIFF
--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -2402,7 +2402,7 @@ start index and the subslice extends to the end of `item`.
 #### sort
 
 ```yag
-{{ $sorted := <list> [options] }}
+{{ $sorted := sort <list> [options] }}
 ```
 
 Returns the given list in a sorted order. The list's items must all be of the same type. The optional `options` argument

--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -1724,7 +1724,7 @@ the end.
 #### printf
 
 ```yag
-{{ $result := <format> <args...> }}
+{{ $result := printf <format> <args...> }}
 ```
 
 Interpolates `args...` according to `format`. See the [Go `fmt` package documentation](https://pkg.go.dev/fmt).


### PR DESCRIPTION
<!-- Please describe the changes this pull request does and why it should be merged -->
`sort` & `printf` are/were missing the actual function within the syntax display in the functions section.
Had a look through everything else and I am pretty sure it was just those that were missed

**Terms**

- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
