### PR TITLE
workflows: use new and maintained mdl implementation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,16 +2,19 @@ name: Lint
 
 on:
   pull_request:
-    paths:
-      - 'content/**/*.md'
 
 jobs:
-  lint-markdown:
+  markdown:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Lint markdown files
-        uses: actionshub/markdownlint@main
+      - uses: actions/checkout@v4
         with:
-          filesToIgnoreRegex: 'all-commands.md|scripts/.*|.github/.*'
+          fetch-depth: 0
+      - name: Lint markdown files
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        continue-on-error: true
+        with:
+          globs: |
+            content/**/*.md
+            !content/docs/core/all-commands.md
+          config: config/.markdownlint.yaml

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,3 +1,0 @@
-git_recurse true
-ignore_front_matter true
-style 'config/markdownlint.rb'

--- a/config/.markdownlint.yaml
+++ b/config/.markdownlint.yaml
@@ -1,49 +1,91 @@
 # Enable all rules; we'll configure some of them below.
-all
+default: true
 
 # MD001: Header levels should only increment by one level at a time.
 # Normally, this is a fair rule, but it does not quite work for our cases,
 # especially in our humongous functions list. So disable it.
-exclude_rule 'MD001'
+MD001: false
 
 # MD002: First header should be a top level header.
 # Some files do not have a top-level header, because it doesn't make sense for
 # them, or just looks incredibly stupid on the rendered page. So disable this
 # entire rule.
-exclude_rule 'MD002'
+MD002: false
 
 # MD004: Unordered list style.
 # Use dashes for unordered lists. All lists. Even sublists.
-rule 'MD004', :style => :dash
+MD004:
+  style: "dash"
 
 # MD013: Line length.
 # Allow lines to be up to 120 characters long, see the .editorconfig file.
 # We also ignore code blocks, because they are often long and should not be
 # wrapped at all. Same goes for tables.
-rule 'MD013', :line_length => 120, :ignore_code_blocks => true, :tables => false
+MD013:
+  line_length: 120
+  code_blocks: false
+  tables: false
 
 # MD024: Multiple headers with the same content.
 # Allow multiple headers with the same content so long they are under different
 # parent headers.
-rule 'MD024', :allow_different_nesting => true
+MD024:
+  siblings_only: true
 
 # MD026: Trailling punctuation in header.
 # Allow question marks (FAQ-style).
-rule 'MD026', :punctuation => '.,;:!'
+MD026:
+  punctuation: ".,;:!"
 
 # MD029: Ordered list item prefix.
 # Should increase in numerical order.
-rule 'MD029', :style => :ordered
+MD029:
+  style: "ordered"
 
 # MD033: Inline HTML.
 # Allow certain HTML elements, because we use them for nicer page layout.
-rule 'MD033', :allowed_elements => 'center, div, sup, br, kbd'
+MD033:
+  allowed_elements: ["center", "div", "sup", "br", "kbd"]
 
 # MD037: Spaces inside emphasis markers.
 # This rule is broken. See https://github.com/markdownlint/markdownlint/issues/84
-exclude_rule 'MD037'
+MD037: false
 
 # MD041: First line in file should be a top-level header.
 # See comment to MD002. It makes no sense to set this to H2 for similar reasons,
 # we have TOML frontmatter with an automatic h1 in the rendered page.
-exclude_rule 'MD041'
+MD041: false
+
+# MD048: Code fence style.
+# Use backticks for code fences.
+MD048:
+  style: "backtick"
+
+# MD049: Emphasis style. (Italics)
+# Use asterisks for italics.
+# MD049:
+#  style: "asterisk"
+#  FIXME: Re-enable this rule once we have fixed all the italics in the docs.
+MD049: false
+
+# MD050: Strong style.
+# Use double asterisks for bold text.
+MD050:
+  style: "asterisk"
+
+# MD051: Link fragments should be valid.
+# Disable this rule, because Hugo already checks for (potentially) broken links.
+MD051: false
+
+# MD052: Reference links and images should use a label that is defined.
+# Similar reasons as MD051, Hugo already checks for broken links.
+MD052: false
+
+# MD053: Link and image reference definitions should be needed.
+# Similar reasons as MD051, Hugo already checks for broken links.
+MD053: false
+
+# MD054: Link and image style.
+# Disable this rule, because it is very extensive and thus painful to configure.
+# By extension, also very painful to fix.
+MD054: false

--- a/content/docs/reference/custom-commands-limits.md
+++ b/content/docs/reference/custom-commands-limits.md
@@ -39,21 +39,21 @@ Various limits in YAGPDB custom commands (CC) for smooth functioning of the bot 
 
 - **Max file size (complexMessage):** 100kB
 - **joinStr max string length:** 1000kB
-- **sendDM:** 1 call per CC -> counter key "send\_dm"
-- **sendTemplate/sendTemplateDM:** 3 calls per CC -> counter key "exec\_child"
-- **addReactions:** 20 calls per CC -> counter key "add\_reaction\_trigger". Each reaction added counts towards the
+- **sendDM:** 1 call per CC -> counter key "send_dm"
+- **sendTemplate/sendTemplateDM:** 3 calls per CC -> counter key "exec_child"
+- **addReactions:** 20 calls per CC -> counter key "add_reaction_trigger". Each reaction added counts towards the
   limit.
-- **addResponseReactions:** 20 calls per CC -> counter key "add\_reaction\_response". Each reaction added counts towards
+- **addResponseReactions:** 20 calls per CC -> counter key "add_reaction_response". Each reaction added counts towards
   the limit.
-- **addMessageReactions:** 20 calls per CC -> counter key "add\_reaction\_message". Each reaction added counts towards
+- **addMessageReactions:** 20 calls per CC -> counter key "add_reaction_message". Each reaction added counts towards
   the limit.
-- **deleteMessageReaction: 1**0 calls per CC -> counter key "del\_reaction\_message". Each removed added counts towards
+- **deleteMessageReaction: 1**0 calls per CC -> counter key "del_reaction_message". Each removed added counts towards
   the limit.
-- **editChannelName/Topic:** 10 calls per CC -> counter key "edit\_channel"
+- **editChannelName/Topic:** 10 calls per CC -> counter key "edit_channel"
 - **regex cache limit:** 10 (this means you cant have more than 10 different regexes on a CC)
-- **onlineCount:** 1 call per cc -> counter key "online\_users"
-- **onlineCountBots:** 1 call per cc -> counter key "online\_bots"
-- **editNickname:** 2 calls per cc -> counter key "edit\_nick"
+- **onlineCount:** 1 call per cc -> counter key "online_users"
+- **onlineCountBots:** 1 call per cc -> counter key "online_bots"
+- **editNickname:** 2 calls per cc -> counter key "edit_nick"
 - **Append/AppendSlice limit:** 10k size limit of resulting slice
 - **exec/execAdmin:** 5 calls per cc -> no key
 - **deleteResponse/deleteMessage/deleteTrigger max delay:** 86400s
@@ -71,21 +71,21 @@ Various limits in YAGPDB custom commands (CC) for smooth functioning of the bot 
 
 ### Database Interactions
 
-- **Calls per CC:** 10/50 (free/prem) -> counter key "db\_interactions"
+- **Calls per CC:** 10/50 (free/prem) -> counter key "db_interactions"
 - Valid for all database commands ->
-   - dbDel/dbDelByID
-   - dbGet
-   - dbIncr
-   - dbSet/dbSetExpire
+  - dbDel/dbDelByID
+  - dbGet
+  - dbIncr
+  - dbSet/dbSetExpire
 
 ### Database Multiple Entry Interactions
 
-Multiple entries all count to general "db\_interactions" limit as well.
+Multiple entries all count to general "db_interactions" limit as well.
 
-- **Calls per CC:** 2/10 (free/prem) -> counter key "db\_multiple"
+- **Calls per CC:** 2/10 (free/prem) -> counter key "db_multiple"
 - Valid for all database multiple entry related commands ->
-   - dbCount
-   - dbDelMultiple
-   - dbGetPattern
-   - dbRank
-   - dbTopEntries
+  - dbCount
+  - dbDelMultiple
+  - dbGetPattern
+  - dbRank
+  - dbTopEntries

--- a/content/docs/reference/custom-interactions.md
+++ b/content/docs/reference/custom-interactions.md
@@ -663,12 +663,12 @@ well.
 Possible initial responses:
 
 - Output text in your script response field. This text will be sent as an interaction response.
-   - You can even use the `ephemeralResponse` function to turn it _ephemeral_.
+  - You can even use the `ephemeralResponse` function to turn it _ephemeral_.
 - Use the `sendResponse` function to send a response as soon as the function runs.
-   - You can also use this to send `embeds` or `complexMessages`.
-   - You'll need to send a `complexMessage` and pass it `"ephemeral" true` as an argument to send _ephemeral_ messages.
-   - `sendResponse` comes in `NoEscape` and `RetID` variants too.
-   - When sending an initial response, `sendResponse` does not need an interaction token, `nil` can be used.
+  - You can also use this to send `embeds` or `complexMessages`.
+  - You'll need to send a `complexMessage` and pass it `"ephemeral" true` as an argument to send _ephemeral_ messages.
+  - `sendResponse` comes in `NoEscape` and `RetID` variants too.
+  - When sending an initial response, `sendResponse` does not need an interaction token, `nil` can be used.
 - Use the `sendModal` function to show the user a modal. You cannot respond to a user submitting a modal by sending them
   another modal.
 - Use the `updateMessage` function to edit the message the command triggered from. This works the same way as editing a
@@ -686,24 +686,24 @@ interaction token of the interaction they should be following up on.
 Possible followups:
 
 - Output text in your script response field. This text will be sent as an interaction followup.
-   - You can even use the `ephemeralResponse` function to turn it _ephemeral_.
+  - You can even use the `ephemeralResponse` function to turn it _ephemeral_.
 - Use the `sendResponse` function to send a followup as soon as the function runs. Note that this function morphs into
   sending followups if an initial response has already been made.
-   - You can also use this to send `embeds` or `complexMessages`.
-   - `sendResponse` comes in `NoEscape` and `RetID` variants too.
-   - It's important to capture the message ID of any
-     followups you'll want to edit or retrieve later, especially if you follow up ephemerally. If you follow up
-     ephemerally without saving the message ID, you'll never be able to interface with that message again.
+  - You can also use this to send `embeds` or `complexMessages`.
+  - `sendResponse` comes in `NoEscape` and `RetID` variants too.
+  - It's important to capture the message ID of any
+    followups you'll want to edit or retrieve later, especially if you follow up ephemerally. If you follow up
+    ephemerally without saving the message ID, you'll never be able to interface with that message again.
 - Use the `editResponse` function to edit an initial response or a followup message.
-   - When editing an initial response, the `messageID` argument should be `nil`.
-   - When editing a followup message, the `messageID` argument is required.
-   - You can still edit any initial responses or followups using the standard `editMessage` function as long as they
-     aren't _ephemeral_.
+  - When editing an initial response, the `messageID` argument should be `nil`.
+  - When editing a followup message, the `messageID` argument is required.
+  - You can still edit any initial responses or followups using the standard `editMessage` function as long as they
+    aren't _ephemeral_.
 - Use the `getResponse` function to get an initial response or a followup message.
-   - When getting an initial response, the `messageID` argument should be `nil`.
-   - When getting a followup message, the `messageID` argument is required.
-   - You can still get any initial responses or followups using the standard `getMessage` function as long as they
-     aren't _ephemeral_.
+  - When getting an initial response, the `messageID` argument should be `nil`.
+  - When getting a followup message, the `messageID` argument is required.
+  - You can still get any initial responses or followups using the standard `getMessage` function as long as they
+    aren't _ephemeral_.
 
 [Interaction Function documentation](/docs/reference/templates/functions#interactions)
 

--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -7,7 +7,7 @@ description = "A list of all available functions in YAGPDB's custom command temp
 Functions are used to take action within template scripts. Some functions accept arguments, and some functions return
 values you can send in your response or use as arguments for other functions.
 
-----
+---
 
 ## Channel
 
@@ -49,8 +49,8 @@ Creates a new forum post. Returns a channel object on success.
 - `name`: The post title. May not be empty. Must be a string.
 - `content`: the initial message's content; may be a string, an embed, or a complex message. May not be empty.
 - `values` (optional): Additional options for the post. May include:
-   - `"slowmode"`: The thread's slowmode in seconds.
-   - `"tags"`: One or more forum tag name or ID. Duplicate and invalid tags are ignored.
+  - `"slowmode"`: The thread's slowmode in seconds.
+  - `"tags"`: One or more forum tag name or ID. Duplicate and invalid tags are ignored.
 
 #### createThread
 
@@ -64,7 +64,7 @@ Creates a new thread in the specified channel. Returns a channel object on succe
 - `message`: either `nil` to create a channel thread, or a message ID to create a message thread.
 - `private`: whether the thread is private. Default `false`.
 - `auto_archive_duration`: how long the thread will show in the channel list after inactivity.<br>
-   Valid values are 60, 1440, 4320, and 10080 minutes. Defaults to 10080 (7 days).
+  Valid values are 60, 1440, 4320, and 10080 minutes. Defaults to 10080 (7 days).
 - `invitable`: whether non-moderators can add other members to the thread. (true/false)
 
 Note: There is no functional difference between a channel thread and a message thread.
@@ -134,10 +134,10 @@ In addition to this, Discord limits the number of channel modifications to 2 per
 Edits the specified thread.
 
 - `opts`: a sdict containing the thread parameters to edit, supporting the following keys (all optional):
-   - `slowmode`: the thread's slowmode in seconds.
-   - `tags`: one or more forum tag name or ID. Duplicate and invalid tags are ignored.
-   - `auto_archive_duration`: how long the thread will show in the channel list after inactivity.
-   - `invitable`: whether non-moderators can add other members to the thread. Defaults to false.
+  - `slowmode`: the thread's slowmode in seconds.
+  - `tags`: one or more forum tag name or ID. Duplicate and invalid tags are ignored.
+  - `auto_archive_duration`: how long the thread will show in the channel list after inactivity.
+  - `invitable`: whether non-moderators can add other members to the thread. Defaults to false.
 
 #### getChannelOrThread
 
@@ -213,7 +213,7 @@ Removes the given member from the given thread.
 
 Unpins the given forum post, which may be specified by its ID or name.
 
-----
+---
 
 ## Database
 
@@ -244,8 +244,8 @@ The argument must be one of the following:
 - `userID`: count entries for the given user ID.
 - `pattern`: count only entries with keys matching the given pattern.
 - `query`: an sdict with the following (all optional) keys:
-   - `userID`: only count entries with a matching UserID field. Defaults to all UserIDs.
-   - `pattern`: only counts entries with keys matching the given pattern. Defaults to all keys.
+  - `userID`: only count entries with a matching UserID field. Defaults to all UserIDs.
+  - `pattern`: only counts entries with keys matching the given pattern. Defaults to all keys.
 
 #### dbDelByID
 
@@ -264,9 +264,9 @@ Deletes a database entry under the given `userID` by its `ID`.
 Deletes up to `amount` entries from the database matching the given criteria. Returns the number of deleted entries.
 
 - `query`: an sdict with the following (all optional) keys:
-   - `userID`: only delete entries with a matching UserID field. Defaults to all UserIDs.
-   - `pattern`: only delete entries with keys matching the given pattern. Defaults to all keys.
-   - `reverse`: whether to delete entries with the lowest value first. Default is `false` (highest value first).
+  - `userID`: only delete entries with a matching UserID field. Defaults to all UserIDs.
+  - `pattern`: only delete entries with keys matching the given pattern. Defaults to all keys.
+  - `reverse`: whether to delete entries with the lowest value first. Default is `false` (highest value first).
 - `amount`: the maximum number of entries to delete, capped at 100.
 - `nSkip`: the number of entries to skip before deleting.
 
@@ -335,9 +335,9 @@ Increments the value of the specified database entry by `incrBy`. Returns the ne
 Returns the rank of the specified entry in the set of entries as defined by `query`.
 
 - `query`: an sdict with the following (all optional) keys:
-   - `userID`: only include entries with the given user ID.
-   - `pattern`: only include entries with keys matching the given pattern.
-   - `reverse`: if `true`, entries with lower values have higher ranks. Default is `false`.
+  - `userID`: only include entries with the given user ID.
+  - `pattern`: only include entries with keys matching the given pattern.
+  - `reverse`: if `true`, entries with lower values have higher ranks. Default is `false`.
 
 #### dbSetExpire
 
@@ -379,7 +379,7 @@ Numerical `dict` keys are retrieved as an `int64`, therefore you'd have to write
 
 {{< /callout >}}
 
-----
+---
 
 ## Encoding and Decoding
 
@@ -451,7 +451,7 @@ byte `0xAB`.
 Returns the escaped value of the textual representation of the arguments in a form suitable for embedding in a URL
 query.
 
-----
+---
 
 ## Executing Custom Commands
 
@@ -510,7 +510,7 @@ Schedules a custom command execution to occur in the future, identified by `key`
 
 To cancel such a scheduled custom command before it runs, use [cancelScheduledUniqueCC](#cancelscheduleduniquecc).
 
-----
+---
 
 ## Interactions
 
@@ -536,16 +536,16 @@ about using interactions, [see here](/docs/reference/custom-interactions).
 Sends a modal to the member who triggered the interaction.
 
 - `modal`: an sdict with the following keys:
-   - `title`: the title of the modal.
-   - `custom_id`: a unique identifier for the modal.
-   - `fields`: a slice of sdicts with the following keys:
-      - `label`: the label for the field.
-      - `placeholder`: the placeholder text for the field.
-      - `value`: the default value for the field.
-      - `required`: whether the field is required.
-      - `style`: the style of the field (1 for short, 2 for long).
-      - `min_length`: the minimum length of the field.
-      - `max_length`: the maximum length of the field.
+  - `title`: the title of the modal.
+  - `custom_id`: a unique identifier for the modal.
+  - `fields`: a slice of sdicts with the following keys:
+    - `label`: the label for the field.
+    - `placeholder`: the placeholder text for the field.
+    - `value`: the default value for the field.
+    - `required`: whether the field is required.
+    - `style`: the style of the field (1 for short, 2 for long).
+    - `min_length`: the minimum length of the field.
+    - `max_length`: the maximum length of the field.
 
 Alternatively, you can create a modal object using the [`cmodal`](#cmodal) function.
 
@@ -687,7 +687,7 @@ Same as [sendResponse](#sendresponse), but also returns the message ID.
 Creates a [button object](https://discord.com/developers/docs/interactions/message-components#button-object) for use in
 interactions.
 
-A link style button *must* have a URL and may not have a Custom ID. All other styles *must* have a Custom ID and cannot
+A link style button _must_ have a URL and may not have a Custom ID. All other styles _must_ have a Custom ID and cannot
 have a URL. All buttons must have either a label or an emoji.
 
 ##### Example
@@ -708,7 +708,7 @@ Creates a [select menu object](https://discord.com/developers/docs/interactions/
 for use in interactions.
 
 The type should be provided as a string: `"text"`, `"user"`, `"role"`, `"mentionable"`, or `"channel"`. Text type menus
-*must* have `options`, while all other types cannot.
+_must_ have `options`, while all other types cannot.
 
 ##### Example
 
@@ -777,7 +777,7 @@ This text is invisible to others!
 Returns the response or follow-up with the specified message ID belonging to the given interaction as a [message
 object](/docs/reference/templates/syntax-and-data#message). Is also valid for ephemeral messages.
 
-----
+---
 
 ## Math
 
@@ -986,7 +986,7 @@ Returns the square root of X as a floating-point number.
 
 Subtracts the provided numbers from each other. Detects the first number's type and returns the result accordingly.
 
-----
+---
 
 ## Member
 
@@ -1076,11 +1076,11 @@ Returns the count of online members on the current server, including bots.
 
 Returns whether the specified member has the specified permission bit.
 
-----
+---
 
 ## Mentions
 
-Certain mentions are escaped by default, such that they don't ping. These functions help you actually *pinging* these
+Certain mentions are escaped by default, such that they don't ping. These functions help you actually _pinging_ these
 special mentions.
 
 #### mentionEveryone
@@ -1125,7 +1125,7 @@ Mentions the role with the given name without escaping it. Searches for first ca
 
 Prefer [mentionRoleID](#mentionroleid), as IDs are guaranteed to be unique and do not change with role edits.
 
-----
+---
 
 ## Message
 
@@ -1180,10 +1180,10 @@ Note that a message sent via [sendMessage](#sendmessage) is not the response---u
 Creates a complex message object for use in [editMessage](#editmessage) or [editMessageNoEscape](#editmessagenoescape).
 
 - `allowed_mentions`: an sdict with the following keys:
-   - `parse`: a slice of accepted values for mentions. May include `users`, `roles`, and `everyone`.
-   - `users`: a slice of user IDs to mention.
-   - `roles`: a slice of role IDs to mention.
-   - `replied_user`: whether to mention the replied user.
+  - `parse`: a slice of accepted values for mentions. May include `users`, `roles`, and `everyone`.
+  - `users`: a slice of user IDs to mention.
+  - `roles`: a slice of role IDs to mention.
+  - `replied_user`: whether to mention the replied user.
 - `content`: the new content for the message.
 - `embed`: an embed object or a slice of up to 10 embed objects.
 - `silent`: whether to suppress push and desktop notifications.
@@ -1200,10 +1200,10 @@ for an example.
 Creates a complex message object for use in [sendMessage](#sendmessage) functions.
 
 - `allowed_mentions`: an sdict with the following keys:
-   - `parse`: a slice of accepted values for mentions. May include `users`, `roles`, and `everyone`.
-   - `users`: a slice of user IDs to mention.
-   - `roles`: a slice of role IDs to mention.
-   - `replied_user`: whether to mention the replied user.
+  - `parse`: a slice of accepted values for mentions. May include `users`, `roles`, and `everyone`.
+  - `users`: a slice of user IDs to mention.
+  - `roles`: a slice of role IDs to mention.
+  - `replied_user`: whether to mention the replied user.
 - `content`: the message content.
 - `embed`: an embed object or a slice of up to 10 embed objects.
 - `file`: the content to print as a file.
@@ -1428,7 +1428,7 @@ Sends a message in the specified channel.
 
 Unpins the specified message.
 
-----
+---
 
 ## Role functions
 
@@ -1653,7 +1653,7 @@ Reports whether the specified target has the specified role ID.
 Reports whether the specified target has the specified role name (case-insensitive).
 `target` may be a user ID, mention, or user object, but must be a member of the server.
 
-----
+---
 
 ## String manipulation
 
@@ -1828,7 +1828,7 @@ Returns the string with all leading and trailing white space removed.
 
 Converts `string` to all uppercase and returns the result.
 
-----
+---
 
 ## Time
 
@@ -1850,23 +1850,23 @@ Formats `time` according to `layout`. Within the layout string, certain phrases 
 with the actual data from `time`: for instance, `Monday` is replaced with the weekday. A list of common placeholders
 follows; see the [Go `time` package documentation](https://pkg.go.dev/time#pkg-constants) for the full list.
 
-| Placeholder | Meaning                      |
-|-------------|------------------------------|
-| Mon         | Weekday (abbreviated)        |
-| Monday      | Weekday (full name)          |
-| 2           | Day of month (single digit)  |
-| 02          | Day of month (zero padded)   |
-| Jan         | Month (abbreviated)          |
-| January     | Month (full name)            |
-| 1           | Month (single digit)         |
-| 01          | Month (zero padded)          |
-| 15          | Hour (24-hour format)        |
-| 3           | Hour (12-hour format)        |
-| 04          | Minute (zero padded)         |
-| 05          | Second (zero padded)         |
-| MST         | Timezone (abbreviated)       |
-| 2006        | Year (full year)             |
-| PM          | AM-PM                        |
+| Placeholder | Meaning                     |
+| ----------- | --------------------------- |
+| Mon         | Weekday (abbreviated)       |
+| Monday      | Weekday (full name)         |
+| 2           | Day of month (single digit) |
+| 02          | Day of month (zero padded)  |
+| Jan         | Month (abbreviated)         |
+| January     | Month (full name)           |
+| 1           | Month (single digit)        |
+| 01          | Month (zero padded)         |
+| 15          | Hour (24-hour format)       |
+| 3           | Hour (12-hour format)       |
+| 04          | Minute (zero padded)        |
+| 05          | Second (zero padded)        |
+| MST         | Timezone (abbreviated)      |
+| 2006        | Year (full year)            |
+| PM          | AM-PM                       |
 
 #### humanizeDurationHours
 
@@ -1984,7 +1984,7 @@ can be done using the `print` function:
 
 {{< /callout >}}
 
-----
+---
 
 ## Type conversion
 
@@ -2055,7 +2055,7 @@ Aliases: `str`.
 
 Converts the input to a string, returning the empty string for invalid inputs.
 
-----
+---
 
 ## User
 
@@ -2091,7 +2091,7 @@ Returns the time object corresponding to when the current user was created.
 
 Returns the full user object specified by `input`, which can be an ID or a mention.
 
-----
+---
 
 ## Miscellaneous
 
@@ -2111,27 +2111,27 @@ Returns a random adjective.
 
 Returns an embed object to send with [sendMessage](#sendmessage)-related functions.
 
-All keys are optional, but the Discord API will reject completey empty embeds, so *some* content is required.
+All keys are optional, but the Discord API will reject completey empty embeds, so _some_ content is required.
 
 - `title`: the title of the embed
 - `url`: the URL to hyperlink the title with
 - `description`: the main text
 - `color`: which color to display on the left side of the embed
 - `fields`: a slice of sdicts with the following keys:
-   - `name`: the name of the field
-   - `value`: which text to have inside this field
-   - `inline`: an optional boolean whether this field should be displayed in-line with other fields
+  - `name`: the name of the field
+  - `value`: which text to have inside this field
+  - `inline`: an optional boolean whether this field should be displayed in-line with other fields
 - `author`: Shows some details at the very top of the embed. Is an sdict with the following keys:
-   - `name`: The name of the author
-   - `url`: the URL to hyperlink the name with
-   - `icon_url`: the author's icon
+  - `name`: The name of the author
+  - `url`: the URL to hyperlink the name with
+  - `icon_url`: the author's icon
 - `thumbnail`: a small image in the top-right corner. Is an sdict with the following keys:
-   - `url`: the image's URL
+  - `url`: the image's URL
 - `image`: an image to display at full width at the bottom of the embed. Is an sdict with the following keys:
-   - `url`: the image's URL
+  - `url`: the image's URL
 - `footer`: Shows some details at the very bottom of the embed. Is an sdict with the following keys:
-   - `text`: the footer's text
-   - `icon_url`: a small icon to display to the left of the footer's text
+  - `text`: the footer's text
+  - `icon_url`: a small icon to display to the left of the footer's text
 - `timestamp`: a (static) timestamp to display to the right of the footer's text
 
 {{< callout context="tip" title="Tip: Custom Commands Embed Generator" icon="outline/rocket" >}}
@@ -2295,8 +2295,8 @@ The result has the `.Get N` and `.IsSet N` methods available, returning the valu
 present, respectively, at position `N` (starting from 0).
 
 - `...cargs`: a list of argument definitions. Must have at least `requiredArgs` elements. Has the following arguments:
-   - `"type"`: the type of this argument as a quoted string.
-   - `"name"`: the name of this argument. Must be a string.
+  - `"type"`: the type of this argument as a quoted string.
+  - `"name"`: the name of this argument. Must be a string.
 
 An argument's `"type"` must be one of the following:
 
@@ -2352,7 +2352,7 @@ string type.
 ```
 
 Same as [sendTemplate](#sendtemplate), but sends it to the triggering user's direct messages instead and returns the
-*response* message's ID.
+_response_ message's ID.
 
 #### sendTemplate
 
@@ -2361,7 +2361,7 @@ Same as [sendTemplate](#sendtemplate), but sends it to the triggering user's dir
 ```
 
 Sends an [Associated Template](/docs/reference/templates/syntax-and-data#associated-templates) to `channel`, with
-optional `data`, returning the *response* message's ID.
+optional `data`, returning the _response_ message's ID.
 
 #### seq
 


### PR DESCRIPTION
The currently used action to lint markdown files does not properly
produce annotations, which would be really useful to have. Use a newer
version that does support annotating files.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**

- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
