### PR TITLE
templates: link to template ticket type in createTicket description

### DIFF
--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -2147,7 +2147,8 @@ community-made embed visualizer for YAGPDB's custom command system.
 {{ $ticket := createTicket <author> <topic> }}
 ```
 
-Creates a new ticket associated to the specified author with given topic.
+Creates a new ticket associated to the specified author with given topic, returning a [template
+ticket](/docs/reference/templates/syntax-and-data#template-ticket) for that ticket.
 
 - `author`: the member to associate this ticket with.
 - `topic`: the topic of this ticket. Must be a string.


### PR DESCRIPTION
Link to the template ticket type table in the createTicket function description
Recommendations on wording are very welcome

Signed-off-by: Galen CC <galen8183@gmail.com>

**Terms**

- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
