### PR TITLE
CC reference: limits: fix formatting and wording

### DIFF
--- a/content/docs/reference/custom-commands-limits.md
+++ b/content/docs/reference/custom-commands-limits.md
@@ -47,7 +47,7 @@ Various limits in YAGPDB custom commands (CC) for smooth functioning of the bot 
   the limit.
 - **addMessageReactions:** 20 calls per CC -> counter key "add_reaction_message". Each reaction added counts towards
   the limit.
-- **deleteMessageReaction: 1**0 calls per CC -> counter key "del_reaction_message". Each removed added counts towards
+- **deleteMessageReaction:** 10 calls per CC -> counter key "del_reaction_message". Each reaction removed counts towards
   the limit.
 - **editChannelName/Topic:** 10 calls per CC -> counter key "edit_channel"
 - **regex cache limit:** 10 (this means you cant have more than 10 different regexes on a CC)


### PR DESCRIPTION
<!-- Please describe the changes this pull request does and why it should be merged -->

This PR fixes bold formatting and rewords the description in the reference > CC limits section for `deleteMessageReaction`

**Terms**

- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
