### PR TITLE
added per channel per minute note

### DIFF
--- a/content/docs/reference/custom-commands-limits.md
+++ b/content/docs/reference/custom-commands-limits.md
@@ -24,6 +24,7 @@ Various limits in YAGPDB custom commands (CC) for smooth functioning of the bot 
 - **Calls per CC:** 1/10 (free/prem) -> counter key "runcc"
 - **StackDepth limit:** 2 (executing with 0 delay)
 - **Delay limit:** int64 limit (292 years)
+- **Channel limit:** 10 executions per channel, per minute
 
 ### scheduleUniqueCC
 

--- a/content/docs/reference/templates/functions.md
+++ b/content/docs/reference/templates/functions.md
@@ -479,6 +479,8 @@ Executes another custom command specified by `ccID`.
 - `data`: some arbitrary data to pass to the executed custom command.
 
 Calling `execCC` with 0 delay sets `.StackDepth` to the current recursion depth and limits it to 2.
+`execCC` is rate-limited strictly to a maximum of 10 delayed custom commands executed per channel per minute. Executions
+beyond this number will be dropped.
 
 ##### Example
 


### PR DESCRIPTION
<!-- Please describe the changes this pull request does and why it should be merged -->
Adding in a known but currently undocumented limitation on execCC. The old docs elaborated on this a bit more, but I felt this was sufficient for the time.

**Terms**

- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
