### PR TITLE
Fix parameter name in cbutton example

### DIFF
--- a/content/learn/advanced/custom-interactions/creating-interactive-elements.md
+++ b/content/learn/advanced/custom-interactions/creating-interactive-elements.md
@@ -18,7 +18,7 @@ also have to attach it to a message. We do that by calling the
 Finally, we send the message.
 
 ```yag
-{{ $button := cbutton "label" "My Cool Button" "custom-id" "buttons-duck" }}
+{{ $button := cbutton "label" "My Cool Button" "custom_id" "buttons-duck" }}
 {{ $m := complexMessage "buttons" $button }}
 {{ sendMessage nil $m }}
 ```


### PR DESCRIPTION
Updated the parameter name from 'custom-id' to 'custom_id' in the cbutton function. I was confused about why I could not trigger my interaction custom command until I realized the custom id key uses an underscore instead of a dash.

<!-- Please describe the changes this pull request does and why it should be merged -->

**Terms**

- [X] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
